### PR TITLE
Add slate template system with aligned video/image layouts

### DIFF
--- a/render_highlight.py
+++ b/render_highlight.py
@@ -424,194 +424,27 @@ def choose_intro_media(intro_files: dict) -> pathlib.Path | None:
                 return options[idx-1]
         print("Invalid choice. Try again.")
 
-def make_slate(player: dict, out_path: pathlib.Path, work: pathlib.Path, intro_media: pathlib.Path | None = None):
+def make_slate(player: dict, out_path: pathlib.Path, work: pathlib.Path,
+               intro_media: pathlib.Path | None = None, template_name: str | None = None):
     """Create intro slate with optional picture or video integration."""
-    
+
     # If intro_media is a video file, handle it directly
     if intro_media and intro_media.suffix.lower() in {".mp4", ".mov", ".avi", ".mkv", ".m4v", ".webm"}:
-        make_slate_with_video(player, out_path, work, intro_media)
+        make_slate_with_video(player, out_path, work, intro_media, template_name=template_name)
         return
-    
+
     # Create image-based slate (with or without picture)
-    make_slate_with_image(player, out_path, work, intro_media)
+    make_slate_with_image(player, out_path, work, intro_media, template_name=template_name)
 
-def make_slate_with_image(player: dict, out_path: pathlib.Path, work: pathlib.Path, intro_image: pathlib.Path | None = None):
-    """Create slate with player profile card design matching phia-profile.jpg style."""
-    W, H = 1920, 1080
-    img = Image.new("RGB", (W, H), (0, 0, 0))
-    draw = ImageDraw.Draw(img)
+def make_slate_with_image(player: dict, out_path: pathlib.Path, work: pathlib.Path,
+                          intro_image: pathlib.Path | None = None, template_name: str | None = None):
+    """Create slate with player profile card using the selected template."""
+    from slate_templates import get_template
 
-    # Player data
-    name = (player.get("name") or "Player Name")
-    pos = (player.get("position") or "")
-    grad = str(player.get("grad_year") or "")
-    club = (player.get("club_team") or "")
-    hs = (player.get("high_school") or "")
-    hw = (player.get("height_weight") or "")
-    gpa = (player.get("gpa") or "")
-    email = (player.get("email") or "")
-    phone = (player.get("phone") or "")
+    template = get_template(template_name)
+    print(f"  Using slate template: {template.display_name}")
 
-    # Draw corner brackets
-    bracket_color = (128, 128, 128)  # Gray color for brackets
-    bracket_size = 60
-    bracket_thickness = 4
-    margin = 80
-    
-    # Top-left bracket
-    draw.line([(margin, margin), (margin + bracket_size, margin)], fill=bracket_color, width=bracket_thickness)
-    draw.line([(margin, margin), (margin, margin + bracket_size)], fill=bracket_color, width=bracket_thickness)
-    
-    # Top-right bracket
-    draw.line([(W - margin - bracket_size, margin), (W - margin, margin)], fill=bracket_color, width=bracket_thickness)
-    draw.line([(W - margin, margin), (W - margin, margin + bracket_size)], fill=bracket_color, width=bracket_thickness)
-    
-    # Bottom-left bracket
-    draw.line([(margin, H - margin - bracket_size), (margin, H - margin)], fill=bracket_color, width=bracket_thickness)
-    draw.line([(margin, H - margin), (margin + bracket_size, H - margin)], fill=bracket_color, width=bracket_thickness)
-    
-    # Bottom-right bracket
-    draw.line([(W - margin, H - margin - bracket_size), (W - margin, H - margin)], fill=bracket_color, width=bracket_thickness)
-    draw.line([(W - margin - bracket_size, H - margin), (W - margin, H - margin)], fill=bracket_color, width=bracket_thickness)
-
-    # Draw "PLAYER PROFILE" header - positioned over the profile text area (75%)
-    header_font = _load_font(48)
-    header_text = "PLAYER PROFILE"
-    header_bbox = draw.textbbox((0, 0), header_text, font=header_font)
-    header_w = header_bbox[2] - header_bbox[0]
-    header_x = int(W * 0.66 - header_w // 2)  # Center at 66% of slate width
-    header_y = 120
-    draw.text((header_x, header_y), header_text, fill=(255, 255, 255), font=header_font)
-
-    # Colors and fonts
-    label_color = (255, 215, 0)  # Gold/yellow color
-    data_color = (255, 255, 255)  # White for data
-    label_font = _load_font(24)
-    data_font = _load_font(36)
-    name_font = _load_font(52)
-    
-    # Build text elements for stats (excluding name which gets special positioning)
-    stats_elements = []
-    
-    # Other elements
-    if pos:
-        stats_elements.append(("POSITION", pos.upper(), label_font, label_color, False))
-    if hw:
-        stats_elements.append(("HEIGHT | WEIGHT", hw, label_font, label_color, False))
-    if grad:
-        stats_elements.append(("GRADUATION YEAR", f"CLASS OF {grad}", label_font, label_color, False))
-    if club:
-        stats_elements.append(("CLUB", club.upper(), label_font, label_color, False))
-    if hs:
-        stats_elements.append(("HIGH SCHOOL", hs.upper(), label_font, label_color, False))
-    if gpa:
-        stats_elements.append(("GPA", str(gpa), label_font, label_color, False))
-    if email:
-        stats_elements.append(("EMAIL", email.lower(), label_font, label_color, False))
-    if phone:
-        stats_elements.append(("PHONE", phone, label_font, label_color, False))
-    
-    if intro_image:
-        # Layout with picture: centered at 25% of slate width
-        pic_area_w = 450
-        pic_area_h = 600
-        pic_area_x = int(W * 0.33 - pic_area_w // 2)  # Center at 33% of slate width
-        pic_area_y = 220
-        
-        # Load and display picture
-        try:
-            player_pic = Image.open(intro_image).convert("RGBA")
-            
-            # Resize picture to fit in the designated area with rounded corners
-            pic_w, pic_h = player_pic.size
-            scale = min(pic_area_w / pic_w, pic_area_h / pic_h, 1.0)
-            new_w, new_h = int(pic_w * scale), int(pic_h * scale)
-            player_pic = player_pic.resize((new_w, new_h), Image.LANCZOS)
-            
-            # Create rounded rectangle mask
-            mask = Image.new("L", (new_w, new_h), 0)
-            mask_draw = ImageDraw.Draw(mask)
-            mask_draw.rounded_rectangle([(0, 0), (new_w, new_h)], radius=20, fill=255)
-            
-            # Apply mask to create rounded corners
-            rounded_pic = Image.new("RGBA", (new_w, new_h), (0, 0, 0, 0))
-            rounded_pic.paste(player_pic, (0, 0))
-            rounded_pic.putalpha(mask)
-            
-            # Center picture in left half
-            pic_x = pic_area_x + (pic_area_w - new_w) // 2
-            pic_y = pic_area_y + (pic_area_h - new_h) // 2
-            
-            # Paste picture onto main image
-            img_rgba = img.convert("RGBA")
-            img_rgba.paste(rounded_pic, (pic_x, pic_y), rounded_pic)
-            img = img_rgba.convert("RGB")
-            draw = ImageDraw.Draw(img)
-            
-        except Exception as e:
-            print(f"Warning: Could not load picture {intro_image}: {e}")
-            intro_image = None  # Fall back to no-picture layout
-    
-    if intro_image:
-        # Player name centered at 25% of slate width (below picture)
-        name_bbox = draw.textbbox((0, 0), name, font=name_font)
-        name_w = name_bbox[2] - name_bbox[0]
-        name_x = int(W * 0.33 - name_w // 2)  # Center at 33% of slate width
-        name_y = pic_area_y + pic_area_h + 30
-        draw.text((name_x, name_y), name, fill=data_color, font=name_font)
-        
-        # Stats centered at 75% of slate width
-        text_center_x = int(W * 0.66)  # Center at 66% of slate width
-        
-        # Calculate total height needed for stats
-        line_spacing = 85
-        total_height = len(stats_elements) * line_spacing - (line_spacing - 50) if stats_elements else 0
-        start_y = (H - total_height) // 2
-        
-        current_y = start_y
-        for label, text, font, color, is_name in stats_elements:
-            # Label and data on separate lines, centered
-            bbox = draw.textbbox((0, 0), label, font=label_font)
-            label_w = bbox[2] - bbox[0]
-            label_x = text_center_x - label_w // 2
-            draw.text((label_x, current_y), label, fill=label_color, font=label_font)
-            
-            bbox = draw.textbbox((0, 0), text, font=data_font)
-            data_w = bbox[2] - bbox[0]
-            data_x = text_center_x - data_w // 2
-            draw.text((data_x, current_y + 35), text, fill=data_color, font=data_font)
-            current_y += line_spacing
-    else:
-        # No picture: name centered below "PLAYER PROFILE" header, then stats below
-        
-        # Player name centered below header
-        name_bbox = draw.textbbox((0, 0), name, font=name_font)
-        name_w = name_bbox[2] - name_bbox[0]
-        name_x = (W - name_w) // 2
-        name_y = header_y + 80  # Below the header
-        draw.text((name_x, name_y), name, fill=data_color, font=name_font)
-        
-        # Stats centered below name
-        text_center_x = W // 2
-        
-        # Calculate total height needed for stats
-        line_spacing = 95
-        total_height = len(stats_elements) * line_spacing - (line_spacing - 60) if stats_elements else 0
-        start_y = name_y + 100  # Below name with some spacing
-        
-        current_y = start_y
-        for label, text, font, color, is_name in stats_elements:
-            # Label and data on separate lines, centered
-            bbox = draw.textbbox((0, 0), label, font=label_font)
-            label_w = bbox[2] - bbox[0]
-            label_x = text_center_x - label_w // 2
-            draw.text((label_x, current_y), label, fill=label_color, font=label_font)
-            
-            bbox = draw.textbbox((0, 0), text, font=data_font)
-            data_w = bbox[2] - bbox[0]
-            data_x = text_center_x - data_w // 2
-            draw.text((data_x, current_y + 35), text, fill=data_color, font=data_font)
-            current_y += line_spacing
+    img = template.render_image_slate(player, intro_image)
 
     slate_png = work / "slate.png"
     img.save(slate_png)
@@ -628,14 +461,19 @@ def make_slate_with_image(player: dict, out_path: pathlib.Path, work: pathlib.Pa
         str(out_path)
     ])
 
-def make_slate_with_video(player: dict, out_path: pathlib.Path, work: pathlib.Path, intro_video: pathlib.Path):
+def make_slate_with_video(player: dict, out_path: pathlib.Path, work: pathlib.Path,
+                          intro_video: pathlib.Path, template_name: str | None = None):
     """Create slate using intro video as background with text overlay."""
+    from slate_templates import get_template
+
+    template = get_template(template_name)
+    print(f"  Using slate template: {template.display_name}")
+
     temp_resized = work / "intro_resized.mp4"
-    temp_with_text = work / "intro_with_text.mp4"
-    
-    # First, resize intro video to 1920x1080 and ensure it's exactly 5 seconds
+
+    # Resize intro video to 1920x1080, exactly 5 seconds
     run([
-        "ffmpeg", "-y",
+        FFMPEG_CMD, "-y",
         "-i", str(intro_video),
         "-vf", f"scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2,fps={FPS}",
         "-t", "5",
@@ -644,65 +482,15 @@ def make_slate_with_video(player: dict, out_path: pathlib.Path, work: pathlib.Pa
         "-an",
         str(temp_resized)
     ])
-    
-    # Create text overlay
-    name = (player.get("name") or "Player Name")
-    pos = (player.get("position") or "")
-    grad = str(player.get("grad_year") or "")
 
-    # Find font with cross-platform support (security: escape font paths)
+    # Get drawtext filters from the template
     font_bold = find_dejavu_font()
-    safe_font_bold = escape_drawtext(font_bold) if font_bold else ""
-    # For regular font, try to find regular variant, fallback to bold
     font_regular = font_bold.replace("-Bold", "") if font_bold and "-Bold" in font_bold else font_bold
-    safe_font_regular = escape_drawtext(font_regular) if font_regular else ""
+    filter_str = template.get_video_drawtext_filters(player, font_bold, font_regular)
 
-    # Escape text content for security
-    safe_name = escape_drawtext(name)
-
-    # Build filter for text overlay
-    text_filters = []
-
-    # Main name with background
-    name_y = "h*0.75"
-    pos_y = "h*0.82"
-    name_filter_parts = [
-        f"drawtext=text='{safe_name}'",
-        f"fontsize=64",
-        f"fontcolor=white",
-        f"x=(w-text_w)/2",
-        f"y={name_y}",
-        f"box=1",
-        f"boxcolor=black@0.7",
-        f"boxborderw=10"
-    ]
-    if safe_font_bold:
-        name_filter_parts.insert(1, f"fontfile={safe_font_bold}")
-    text_filters.append(":".join(name_filter_parts))
-
-    # Position and grad year
-    if pos or grad:
-        pos_line = pos + (f"  •  Class of {grad}" if grad else "")
-        safe_pos_line = escape_drawtext(pos_line)
-        pos_filter_parts = [
-            f"drawtext=text='{safe_pos_line}'",
-            f"fontsize=40",
-            f"fontcolor=white",
-            f"x=(w-text_w)/2",
-            f"y={pos_y}",
-            f"box=1",
-            f"boxcolor=black@0.7",
-            f"boxborderw=8"
-        ]
-        if safe_font_regular:
-            pos_filter_parts.insert(1, f"fontfile={safe_font_regular}")
-        text_filters.append(":".join(pos_filter_parts))
-    
-    filter_str = ",".join(text_filters)
-    
     # Apply text overlay
     run([
-        "ffmpeg", "-y",
+        FFMPEG_CMD, "-y",
         "-i", str(temp_resized),
         "-vf", filter_str,
         "-c:v", "libx264", "-preset", "veryfast", "-crf", str(CRF),
@@ -710,7 +498,7 @@ def make_slate_with_video(player: dict, out_path: pathlib.Path, work: pathlib.Pa
         "-an",
         str(out_path)
     ])
-    
+
     # Clean up temp file
     temp_resized.unlink(missing_ok=True)
 
@@ -979,6 +767,8 @@ def main():
     ap.add_argument("--dir", type=str, help="Full path to athlete or project folder")
     ap.add_argument("--keep-work", action="store_true")
     ap.add_argument("--reset-intro", action="store_true", help="Reset intro media selection and choose again")
+    ap.add_argument("--slate-template", type=str, default=None,
+                    help="Slate template name (classic, modern, bold, cinematic, clean)")
     args = ap.parse_args()
 
     athlete_dir = None
@@ -1190,7 +980,9 @@ def main():
                 print(f"Warning: Intro media file not found: {intro_media}")
                 intro_media = None
 
-        make_slate(data.get("player", {}), slate, work, intro_media)
+        # Determine slate template: CLI override > project.json > default
+        slate_template = args.slate_template or data.get("slate_template")
+        make_slate(data.get("player", {}), slate, work, intro_media, template_name=slate_template)
         outputs = [slate, body]
 
     final = output / "final.mp4"

--- a/slate_template_chooser.py
+++ b/slate_template_chooser.py
@@ -1,0 +1,172 @@
+# Copyright (c) 2025 John Hull
+# Licensed under the MIT License - see LICENSE file
+"""Tkinter dialog for choosing a slate template with visual previews."""
+
+from __future__ import annotations
+
+import pathlib
+import tkinter as tk
+from tkinter import ttk
+
+from PIL import Image, ImageTk
+
+from slate_templates import get_template, list_templates
+
+
+class SlateTemplateChooser:
+    """Modal dialog with thumbnail grid and large preview for selecting a slate template.
+
+    Usage::
+
+        result = SlateTemplateChooser.choose(parent, player_data, intro_image, current="classic")
+        # result is a template name string, or None if cancelled
+    """
+
+    THUMB_W, THUMB_H = 150, 84
+    PREVIEW_W, PREVIEW_H = 640, 360
+
+    def __init__(self, parent: tk.Tk | tk.Toplevel, player: dict,
+                 intro_image: pathlib.Path | None = None,
+                 current: str | None = None):
+        self.result: str | None = None
+        self.player = player
+        self.intro_image = intro_image
+        self.selected: str = current or "classic"
+
+        self.templates = list_templates()
+        self._thumb_images: dict[str, ImageTk.PhotoImage] = {}
+        self._full_images: dict[str, Image.Image] = {}
+
+        # ── window ─────────────────────────────────────────────
+        self.dialog = tk.Toplevel(parent)
+        self.dialog.title("Choose Slate Template")
+        self.dialog.geometry("820x560")
+        self.dialog.resizable(False, False)
+        self.dialog.transient(parent)
+        self.dialog.grab_set()
+
+        # Centre on parent
+        px = parent.winfo_rootx() + (parent.winfo_width() - 820) // 2
+        py = parent.winfo_rooty() + (parent.winfo_height() - 560) // 2
+        self.dialog.geometry(f"+{max(px, 0)}+{max(py, 0)}")
+
+        self._build_ui()
+        self._render_previews()
+        self._select(self.selected)
+
+        self.dialog.protocol("WM_DELETE_WINDOW", self._cancel)
+        self.dialog.wait_window()
+
+    # ── UI construction ────────────────────────────────────────
+
+    def _build_ui(self):
+        main = tk.Frame(self.dialog, padx=15, pady=10)
+        main.pack(fill="both", expand=True)
+
+        # Title
+        tk.Label(main, text="Choose Slate Template",
+                 font=("Segoe UI", 14, "bold")).pack(pady=(0, 10))
+
+        # ── thumbnail row ──────────────────────────────────────
+        thumb_frame = tk.Frame(main)
+        thumb_frame.pack(fill="x", pady=(0, 12))
+
+        self._thumb_buttons: dict[str, tk.Label] = {}
+        for tpl in self.templates:
+            col = tk.Frame(thumb_frame)
+            col.pack(side="left", expand=True, padx=4)
+
+            lbl = tk.Label(col, relief="flat", bd=3, cursor="hand2")
+            lbl.pack()
+            lbl.bind("<Button-1>", lambda e, n=tpl.name: self._select(n))
+            self._thumb_buttons[tpl.name] = lbl
+
+            tk.Label(col, text=tpl.display_name,
+                     font=("Segoe UI", 9)).pack(pady=(2, 0))
+
+        # ── preview + info area ────────────────────────────────
+        preview_row = tk.Frame(main)
+        preview_row.pack(fill="both", expand=True)
+
+        self._preview_label = tk.Label(preview_row, bg="#222222")
+        self._preview_label.pack(side="left", padx=(0, 15))
+
+        info_frame = tk.Frame(preview_row)
+        info_frame.pack(side="left", fill="both", expand=True, anchor="n", pady=10)
+
+        self._info_name = tk.Label(info_frame, text="",
+                                   font=("Segoe UI", 13, "bold"), anchor="w")
+        self._info_name.pack(fill="x", pady=(0, 6))
+
+        self._info_desc = tk.Label(info_frame, text="", wraplength=200,
+                                   font=("Segoe UI", 10), fg="#555",
+                                   anchor="nw", justify="left")
+        self._info_desc.pack(fill="x")
+
+        # ── buttons ────────────────────────────────────────────
+        btn_frame = tk.Frame(main)
+        btn_frame.pack(fill="x", pady=(12, 0))
+
+        tk.Button(btn_frame, text="Select", command=self._confirm,
+                  bg="#007ACC", fg="white", font=("Segoe UI", 10, "bold"),
+                  width=12).pack(side="right", padx=(8, 0))
+        tk.Button(btn_frame, text="Cancel", command=self._cancel,
+                  font=("Segoe UI", 10), width=10).pack(side="right")
+
+    # ── preview rendering ──────────────────────────────────────
+
+    def _render_previews(self):
+        """Render full-size images and create thumbnail PhotoImages."""
+        for tpl in self.templates:
+            full = tpl.render_image_slate(self.player, self.intro_image)
+            self._full_images[tpl.name] = full
+
+            thumb = full.resize((self.THUMB_W, self.THUMB_H), Image.LANCZOS)
+            photo = ImageTk.PhotoImage(thumb)
+            self._thumb_images[tpl.name] = photo
+            self._thumb_buttons[tpl.name].config(image=photo)
+
+    # ── selection logic ────────────────────────────────────────
+
+    def _select(self, name: str):
+        self.selected = name
+
+        # Highlight selected thumbnail border
+        for tname, btn in self._thumb_buttons.items():
+            if tname == name:
+                btn.config(relief="solid", bd=3, highlightbackground="#007ACC",
+                           highlightcolor="#007ACC", highlightthickness=3)
+            else:
+                btn.config(relief="flat", bd=3, highlightthickness=0)
+
+        # Update large preview
+        full = self._full_images.get(name)
+        if full:
+            preview = full.resize((self.PREVIEW_W, self.PREVIEW_H), Image.LANCZOS)
+            self._preview_photo = ImageTk.PhotoImage(preview)
+            self._preview_label.config(image=self._preview_photo)
+
+        # Update info text
+        tpl = get_template(name)
+        self._info_name.config(text=tpl.display_name)
+        self._info_desc.config(text=tpl.description)
+
+    # ── dialog actions ─────────────────────────────────────────
+
+    def _confirm(self):
+        self.result = self.selected
+        self.dialog.destroy()
+
+    def _cancel(self):
+        self.result = None
+        self.dialog.destroy()
+
+    # ── convenience class method ───────────────────────────────
+
+    @classmethod
+    def choose(cls, parent: tk.Tk | tk.Toplevel, player: dict,
+               intro_image: pathlib.Path | None = None,
+               current: str | None = None) -> str | None:
+        """Show the chooser dialog and return selected template name, or None."""
+        dlg = cls(parent, player, intro_image, current)
+        return dlg.result

--- a/slate_templates/__init__.py
+++ b/slate_templates/__init__.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2025 John Hull
+# Licensed under the MIT License - see LICENSE file
+"""Slate template registry.
+
+Import a template by name::
+
+    from slate_templates import get_template
+    tpl = get_template("modern")          # returns ModernTemplate instance
+    img = tpl.render_image_slate(player, intro_path)
+"""
+
+from __future__ import annotations
+
+from .base import SlateTemplate
+from .classic import ClassicTemplate
+from .modern import ModernTemplate
+from .bold import BoldTemplate
+from .cinematic import CinematicTemplate
+from .clean import CleanTemplate
+
+# Ordered list – this order is used in the chooser GUI
+_TEMPLATE_CLASSES: list[type[SlateTemplate]] = [
+    ClassicTemplate,
+    ModernTemplate,
+    BoldTemplate,
+    CinematicTemplate,
+    CleanTemplate,
+]
+
+TEMPLATES: dict[str, SlateTemplate] = {cls.name: cls() for cls in _TEMPLATE_CLASSES}
+
+DEFAULT_TEMPLATE = "classic"
+
+
+def get_template(name: str | None) -> SlateTemplate:
+    """Return a template instance by name, falling back to classic."""
+    if name and name in TEMPLATES:
+        return TEMPLATES[name]
+    return TEMPLATES[DEFAULT_TEMPLATE]
+
+
+def list_templates() -> list[SlateTemplate]:
+    """Return all templates in display order."""
+    return list(TEMPLATES.values())

--- a/slate_templates/base.py
+++ b/slate_templates/base.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2025 John Hull
+# Licensed under the MIT License - see LICENSE file
+"""Base class and shared utilities for slate templates."""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import platform
+from abc import ABC, abstractmethod
+
+from PIL import Image, ImageDraw, ImageFont
+
+
+# ── shared font utilities ──────────────────────────────────────────
+
+def load_font(size: int, bold: bool = False) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    """Load a TrueType font at the given size, falling back to default.
+
+    Args:
+        size: Font point size.
+        bold: If True, prefer a bold variant.
+    """
+    if bold:
+        candidates = [
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+            "/usr/share/fonts/dejavu/DejaVuSans-Bold.ttf",
+            "/usr/share/fonts/TTF/DejaVuSans-Bold.ttf",
+            "/usr/share/fonts/truetype/freefont/FreeSansBold.ttf",
+        ]
+    else:
+        candidates = [
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf",
+            "/usr/share/fonts/dejavu/DejaVuSans.ttf",
+            "/usr/share/fonts/TTF/DejaVuSans.ttf",
+            "/usr/share/fonts/truetype/freefont/FreeSans.ttf",
+        ]
+
+    # Add cross-platform paths
+    system = platform.system()
+    if system == "Darwin":
+        candidates += [
+            "/System/Library/Fonts/Supplemental/DejaVuSans-Bold.ttf" if bold
+            else "/System/Library/Fonts/Supplemental/DejaVuSans.ttf",
+            "/Library/Fonts/DejaVuSans-Bold.ttf" if bold
+            else "/Library/Fonts/DejaVuSans.ttf",
+        ]
+    elif system == "Windows":
+        candidates += [
+            "C:/Windows/Fonts/DejaVuSans-Bold.ttf" if bold
+            else "C:/Windows/Fonts/DejaVuSans.ttf",
+        ]
+
+    for path in candidates:
+        try:
+            return ImageFont.truetype(path, size)
+        except Exception:
+            pass
+    return ImageFont.load_default()
+
+
+def escape_drawtext(text: str) -> str:
+    """Escape special characters for FFmpeg drawtext filter.
+
+    FFmpeg drawtext has many special chars that need escaping:
+    backslash, colon, percent, curly braces, square brackets, single quotes.
+    """
+    text = text.replace("\\", "\\\\")
+    text = text.replace(":", "\\:")
+    text = text.replace("%", "\\%")
+    text = text.replace("{", "\\{")
+    text = text.replace("}", "\\}")
+    text = text.replace("[", "\\[")
+    text = text.replace("]", "\\]")
+    text = text.replace("'", "'\\''")
+    return text
+
+
+def find_dejavu_font() -> str:
+    """Find DejaVu Sans Bold font across platforms.
+
+    Returns path to font file, or empty string to use FFmpeg default.
+    """
+    system = platform.system()
+    candidates: list[str] = []
+    allowed_dirs: list[str] = []
+
+    if system == "Linux":
+        candidates = [
+            "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+            "/usr/share/fonts/dejavu/DejaVuSans-Bold.ttf",
+            "/usr/share/fonts/TTF/DejaVuSans-Bold.ttf",
+        ]
+        allowed_dirs = ["/usr/share/fonts", "/usr/local/share/fonts"]
+    elif system == "Darwin":
+        candidates = [
+            "/System/Library/Fonts/Supplemental/DejaVuSans-Bold.ttf",
+            "/Library/Fonts/DejaVuSans-Bold.ttf",
+            str(pathlib.Path.home() / "Library/Fonts/DejaVuSans-Bold.ttf"),
+        ]
+        allowed_dirs = ["/System/Library/Fonts", "/Library/Fonts",
+                        str(pathlib.Path.home() / "Library/Fonts")]
+    elif system == "Windows":
+        candidates = [
+            "C:/Windows/Fonts/DejaVuSans-Bold.ttf",
+            str(pathlib.Path.home() / "AppData/Local/Microsoft/Windows/Fonts/DejaVuSans-Bold.ttf"),
+        ]
+        allowed_dirs = ["C:/Windows/Fonts", "C:\\Windows\\Fonts",
+                        str(pathlib.Path.home() / "AppData/Local/Microsoft/Windows/Fonts")]
+
+    for font_path in candidates:
+        font_file = pathlib.Path(font_path).resolve()
+        if font_file.exists():
+            if font_file.suffix.lower() not in ['.ttf', '.otf', '.ttc']:
+                continue
+            if not os.access(font_file, os.R_OK):
+                continue
+            font_str = str(font_file)
+            if not any(font_str.startswith(d) for d in allowed_dirs):
+                continue
+            return str(font_file)
+
+    print("Warning: DejaVu Sans Bold font not found, using FFmpeg default font")
+    return ""
+
+
+def find_dejavu_regular() -> str:
+    """Find DejaVu Sans (regular) font. Falls back to bold if not found."""
+    bold = find_dejavu_font()
+    if bold:
+        regular = bold.replace("-Bold", "")
+        if pathlib.Path(regular).exists():
+            return regular
+    return bold
+
+
+# ── helper to extract player fields ────────────────────────────────
+
+def extract_player_fields(player: dict) -> dict:
+    """Pull common player fields from the data dict, with safe defaults."""
+    return {
+        "name": player.get("name") or "Player Name",
+        "title": player.get("title") or "",
+        "position": player.get("position") or "",
+        "grad_year": str(player.get("grad_year") or ""),
+        "club_team": player.get("club_team") or "",
+        "high_school": player.get("high_school") or "",
+        "height_weight": player.get("height_weight") or "",
+        "gpa": player.get("gpa") or "",
+        "email": player.get("email") or "",
+        "phone": player.get("phone") or "",
+    }
+
+
+# ── abstract base ──────────────────────────────────────────────────
+
+class SlateTemplate(ABC):
+    """Abstract base for slate template designs."""
+
+    name: str           # e.g. "classic"
+    display_name: str   # e.g. "Classic"
+    description: str    # One-line summary for the GUI
+
+    # ── abstract methods that each template MUST implement ──
+
+    @abstractmethod
+    def render_image_slate(self, player: dict, intro_image: pathlib.Path | None) -> Image.Image:
+        """Return a 1920x1080 PIL Image for image-based (or text-only) slates."""
+
+    @abstractmethod
+    def get_video_drawtext_filters(self, player: dict, font_bold: str, font_regular: str) -> str:
+        """Return an FFmpeg drawtext filter string for video-background slates."""
+
+    # ── optional override ──
+
+    def render_preview(self, player: dict, intro_image: pathlib.Path | None) -> Image.Image:
+        """Return a 384x216 thumbnail preview (default: render full then downscale)."""
+        full = self.render_image_slate(player, intro_image)
+        return full.resize((384, 216), Image.LANCZOS)

--- a/slate_templates/bold.py
+++ b/slate_templates/bold.py
@@ -1,0 +1,232 @@
+# Copyright (c) 2025 John Hull
+# Licensed under the MIT License - see LICENSE file
+"""Bold slate template.
+
+Huge centered name, photo as darkened full-bleed background,
+minimal info footer.  No photo → charcoal background.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from PIL import Image, ImageDraw, ImageEnhance, ImageFilter
+
+from .base import SlateTemplate, load_font, escape_drawtext, extract_player_fields
+
+
+class BoldTemplate(SlateTemplate):
+    name = "bold"
+    display_name = "Bold"
+    description = "Huge centered name, full-bleed photo bg, minimal info"
+
+    _CHARCOAL = (45, 45, 48)
+    _GOLD = (218, 165, 32)
+
+    # ── image slate ────────────────────────────────────────────────
+
+    def render_image_slate(self, player: dict, intro_image: pathlib.Path | None) -> Image.Image:
+        W, H = 1920, 1080
+        p = extract_player_fields(player)
+
+        if intro_image:
+            try:
+                bg = Image.open(intro_image).convert("RGB")
+                # Scale to cover 1920x1080
+                bg_w, bg_h = bg.size
+                scale = max(W / bg_w, H / bg_h)
+                bg = bg.resize((int(bg_w * scale), int(bg_h * scale)), Image.LANCZOS)
+                # Top-anchored crop — keep head visible
+                cx = bg.size[0] // 2
+                bg = bg.crop((cx - W // 2, 0, cx + W // 2, H))
+                # Darken: 50% black overlay
+                bg = ImageEnhance.Brightness(bg).enhance(0.5)
+                # Slight blur for depth
+                bg = bg.filter(ImageFilter.GaussianBlur(radius=3))
+                img = bg
+            except Exception as e:
+                print(f"Warning: Could not load picture {intro_image}: {e}")
+                img = Image.new("RGB", (W, H), self._CHARCOAL)
+        else:
+            img = Image.new("RGB", (W, H), self._CHARCOAL)
+
+        draw = ImageDraw.Draw(img)
+
+        # Title above name (if set)
+        center_y = H // 2 - 100
+        if p["title"]:
+            title_font = load_font(44, bold=True)
+            tb = draw.textbbox((0, 0), p["title"].upper(), font=title_font)
+            tw = tb[2] - tb[0]
+            draw.text(((W - tw) // 2, center_y - 70), p["title"].upper(),
+                      fill=self._GOLD, font=title_font)
+
+        # Massive centred name
+        name_font = load_font(96, bold=True)
+        name_text = p["name"].upper()
+        bb = draw.textbbox((0, 0), name_text, font=name_font)
+        nw = bb[2] - bb[0]
+        draw.text(((W - nw) // 2, center_y), name_text, fill=(255, 255, 255), font=name_font)
+
+        # Position in gold below name
+        pos_bottom_y = center_y + 130
+        if p["position"]:
+            pos_font = load_font(48, bold=True)
+            pos_text = p["position"].upper()
+            bb = draw.textbbox((0, 0), pos_text, font=pos_font)
+            pw = bb[2] - bb[0]
+            draw.text(((W - pw) // 2, pos_bottom_y), pos_text, fill=self._GOLD, font=pos_font)
+            pos_bottom_y += 60
+
+        # Footer line 1: grad year · club · high school
+        footer_font = load_font(28)
+        line1_parts = []
+        if p["grad_year"]:
+            line1_parts.append(f"Class of {p['grad_year']}")
+        if p["club_team"]:
+            line1_parts.append(p["club_team"])
+        if p["high_school"]:
+            line1_parts.append(p["high_school"])
+
+        # Footer line 2: height/weight · gpa · email · phone
+        line2_parts = []
+        if p["height_weight"]:
+            line2_parts.append(p["height_weight"])
+        if p["gpa"]:
+            line2_parts.append(f"GPA {p['gpa']}")
+        if p["email"]:
+            line2_parts.append(p["email"].lower())
+        if p["phone"]:
+            line2_parts.append(p["phone"])
+
+        footer_y = H - 80
+        if line1_parts and line2_parts:
+            footer_y = H - 120
+        elif line1_parts or line2_parts:
+            footer_y = H - 80
+
+        if line1_parts:
+            text = "  ·  ".join(line1_parts)
+            bb = draw.textbbox((0, 0), text, font=footer_font)
+            fw = bb[2] - bb[0]
+            draw.text(((W - fw) // 2, footer_y), text, fill=(200, 200, 200), font=footer_font)
+            footer_y += 40
+
+        if line2_parts:
+            text = "  ·  ".join(line2_parts)
+            bb = draw.textbbox((0, 0), text, font=footer_font)
+            fw = bb[2] - bb[0]
+            draw.text(((W - fw) // 2, footer_y), text, fill=(170, 170, 170), font=footer_font)
+
+        return img
+
+    # ── video drawtext ─────────────────────────────────────────────
+
+    def get_video_drawtext_filters(self, player: dict, font_bold: str, font_regular: str) -> str:
+        p = extract_player_fields(player)
+        safe_name = escape_drawtext(p["name"].upper())
+        sfb = escape_drawtext(font_bold) if font_bold else ""
+        sfr = escape_drawtext(font_regular) if font_regular else ""
+
+        filters: list[str] = []
+
+        # Title above name
+        if p["title"]:
+            safe_title = escape_drawtext(p["title"].upper())
+            parts = [
+                f"drawtext=text='{safe_title}'",
+                f"fontsize=44",
+                f"fontcolor=#daa520",
+                f"x=(w-text_w)/2",
+                f"y=(h-text_h)/2-120",
+                f"box=1",
+                f"boxcolor=black@0.5",
+                f"boxborderw=10",
+            ]
+            if sfb:
+                parts.insert(1, f"fontfile={sfb}")
+            filters.append(":".join(parts))
+
+        # Big centred name
+        parts = [
+            f"drawtext=text='{safe_name}'",
+            f"fontsize=96",
+            f"fontcolor=white",
+            f"x=(w-text_w)/2",
+            f"y=(h-text_h)/2-40",
+            f"box=1",
+            f"boxcolor=black@0.5",
+            f"boxborderw=15",
+        ]
+        if sfb:
+            parts.insert(1, f"fontfile={sfb}")
+        filters.append(":".join(parts))
+
+        # Position in gold
+        if p["position"]:
+            safe_pos = escape_drawtext(p["position"].upper())
+            parts = [
+                f"drawtext=text='{safe_pos}'",
+                f"fontsize=48",
+                f"fontcolor=#daa520",
+                f"x=(w-text_w)/2",
+                f"y=(h)/2+40",
+                f"box=1",
+                f"boxcolor=black@0.5",
+                f"boxborderw=10",
+            ]
+            if sfb:
+                parts.insert(1, f"fontfile={sfb}")
+            filters.append(":".join(parts))
+
+        # Footer line 1: grad year · club · high school
+        line1_parts = []
+        if p["grad_year"]:
+            line1_parts.append(f"Class of {p['grad_year']}")
+        if p["club_team"]:
+            line1_parts.append(p["club_team"])
+        if p["high_school"]:
+            line1_parts.append(p["high_school"])
+        if line1_parts:
+            safe_line1 = escape_drawtext("  ·  ".join(line1_parts))
+            parts = [
+                f"drawtext=text='{safe_line1}'",
+                f"fontsize=28",
+                f"fontcolor=#cccccc",
+                f"x=(w-text_w)/2",
+                f"y=h-130",
+                f"box=1",
+                f"boxcolor=black@0.5",
+                f"boxborderw=8",
+            ]
+            if sfr:
+                parts.insert(1, f"fontfile={sfr}")
+            filters.append(":".join(parts))
+
+        # Footer line 2: height/weight · gpa · email · phone
+        line2_parts = []
+        if p["height_weight"]:
+            line2_parts.append(p["height_weight"])
+        if p["gpa"]:
+            line2_parts.append(f"GPA {p['gpa']}")
+        if p["email"]:
+            line2_parts.append(p["email"].lower())
+        if p["phone"]:
+            line2_parts.append(p["phone"])
+        if line2_parts:
+            safe_line2 = escape_drawtext("  ·  ".join(line2_parts))
+            parts = [
+                f"drawtext=text='{safe_line2}'",
+                f"fontsize=24",
+                f"fontcolor=#aaaaaa",
+                f"x=(w-text_w)/2",
+                f"y=h-85",
+                f"box=1",
+                f"boxcolor=black@0.5",
+                f"boxborderw=6",
+            ]
+            if sfr:
+                parts.insert(1, f"fontfile={sfr}")
+            filters.append(":".join(parts))
+
+        return ",".join(filters)

--- a/slate_templates/bold.py
+++ b/slate_templates/bold.py
@@ -130,7 +130,7 @@ class BoldTemplate(SlateTemplate):
 
         filters: list[str] = []
 
-        # Title above name
+        # Title above name – matches image center_y-70 = 370
         if p["title"]:
             safe_title = escape_drawtext(p["title"].upper())
             parts = [
@@ -138,7 +138,7 @@ class BoldTemplate(SlateTemplate):
                 f"fontsize=44",
                 f"fontcolor=#daa520",
                 f"x=(w-text_w)/2",
-                f"y=(h-text_h)/2-120",
+                f"y=370",
                 f"box=1",
                 f"boxcolor=black@0.5",
                 f"boxborderw=10",
@@ -147,13 +147,13 @@ class BoldTemplate(SlateTemplate):
                 parts.insert(1, f"fontfile={sfb}")
             filters.append(":".join(parts))
 
-        # Big centred name
+        # Big centred name – matches image center_y = 440
         parts = [
             f"drawtext=text='{safe_name}'",
             f"fontsize=96",
             f"fontcolor=white",
             f"x=(w-text_w)/2",
-            f"y=(h-text_h)/2-40",
+            f"y=440",
             f"box=1",
             f"boxcolor=black@0.5",
             f"boxborderw=15",
@@ -162,7 +162,7 @@ class BoldTemplate(SlateTemplate):
             parts.insert(1, f"fontfile={sfb}")
         filters.append(":".join(parts))
 
-        # Position in gold
+        # Position in gold – matches image center_y+130 = 570
         if p["position"]:
             safe_pos = escape_drawtext(p["position"].upper())
             parts = [
@@ -170,7 +170,7 @@ class BoldTemplate(SlateTemplate):
                 f"fontsize=48",
                 f"fontcolor=#daa520",
                 f"x=(w-text_w)/2",
-                f"y=(h)/2+40",
+                f"y=570",
                 f"box=1",
                 f"boxcolor=black@0.5",
                 f"boxborderw=10",
@@ -179,7 +179,7 @@ class BoldTemplate(SlateTemplate):
                 parts.insert(1, f"fontfile={sfb}")
             filters.append(":".join(parts))
 
-        # Footer line 1: grad year · club · high school
+        # Footer line 1 – matches image H-120 = 960
         line1_parts = []
         if p["grad_year"]:
             line1_parts.append(f"Class of {p['grad_year']}")
@@ -194,7 +194,7 @@ class BoldTemplate(SlateTemplate):
                 f"fontsize=28",
                 f"fontcolor=#cccccc",
                 f"x=(w-text_w)/2",
-                f"y=h-130",
+                f"y=h-120",
                 f"box=1",
                 f"boxcolor=black@0.5",
                 f"boxborderw=8",
@@ -203,7 +203,7 @@ class BoldTemplate(SlateTemplate):
                 parts.insert(1, f"fontfile={sfr}")
             filters.append(":".join(parts))
 
-        # Footer line 2: height/weight · gpa · email · phone
+        # Footer line 2 – matches image H-80 = 1000
         line2_parts = []
         if p["height_weight"]:
             line2_parts.append(p["height_weight"])
@@ -217,10 +217,10 @@ class BoldTemplate(SlateTemplate):
             safe_line2 = escape_drawtext("  ·  ".join(line2_parts))
             parts = [
                 f"drawtext=text='{safe_line2}'",
-                f"fontsize=24",
+                f"fontsize=28",
                 f"fontcolor=#aaaaaa",
                 f"x=(w-text_w)/2",
-                f"y=h-85",
+                f"y=h-80",
                 f"box=1",
                 f"boxcolor=black@0.5",
                 f"boxborderw=6",

--- a/slate_templates/cinematic.py
+++ b/slate_templates/cinematic.py
@@ -1,0 +1,254 @@
+# Copyright (c) 2025 John Hull
+# Licensed under the MIT License - see LICENSE file
+"""Cinematic slate template.
+
+Dark gray with 100px letterbox bars top/bottom, subtle noise texture,
+bottom-left aligned text, photo as darkened background if available.
+Only shows name + position + grad_year.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import random
+
+from PIL import Image, ImageDraw, ImageEnhance, ImageFilter
+
+from .base import SlateTemplate, load_font, escape_drawtext, extract_player_fields
+
+
+class CinematicTemplate(SlateTemplate):
+    name = "cinematic"
+    display_name = "Cinematic"
+    description = "Letterbox bars, film-grain noise, bottom-left text"
+
+    _BG = (30, 30, 32)
+    _BAR = (0, 0, 0)
+    _TEXT_WARM = (240, 230, 215)
+    _TEXT_MUTED = (160, 155, 145)
+    _BAR_H = 100
+
+    @staticmethod
+    def _add_noise(img: Image.Image, strength: int = 12) -> Image.Image:
+        """Add subtle film-grain noise texture."""
+        rng = random.Random(42)  # deterministic for consistency
+        noise = Image.new("RGB", img.size)
+        pixels = noise.load()
+        w, h = img.size
+        for y in range(h):
+            for x in range(w):
+                n = rng.randint(-strength, strength)
+                pixels[x, y] = (128 + n, 128 + n, 128 + n)
+        from PIL import ImageChops
+        # Blend: soft light approximation via overlay at low opacity
+        blended = Image.blend(img, noise, 0.06)
+        return blended
+
+    # ── image slate ────────────────────────────────────────────────
+
+    def render_image_slate(self, player: dict, intro_image: pathlib.Path | None) -> Image.Image:
+        W, H = 1920, 1080
+        p = extract_player_fields(player)
+
+        if intro_image:
+            try:
+                bg = Image.open(intro_image).convert("RGB")
+                bg_w, bg_h = bg.size
+                scale = max(W / bg_w, H / bg_h)
+                bg = bg.resize((int(bg_w * scale), int(bg_h * scale)), Image.LANCZOS)
+                # Top-anchored crop — keep head visible
+                cx = bg.size[0] // 2
+                bg = bg.crop((cx - W // 2, 0, cx + W // 2, H))
+                bg = ImageEnhance.Brightness(bg).enhance(0.35)
+                bg = bg.filter(ImageFilter.GaussianBlur(radius=2))
+                img = bg
+            except Exception as e:
+                print(f"Warning: Could not load picture {intro_image}: {e}")
+                img = Image.new("RGB", (W, H), self._BG)
+        else:
+            img = Image.new("RGB", (W, H), self._BG)
+
+        # Add noise
+        img = self._add_noise(img)
+
+        draw = ImageDraw.Draw(img)
+
+        # Letterbox bars
+        draw.rectangle([(0, 0), (W, self._BAR_H)], fill=self._BAR)
+        draw.rectangle([(0, H - self._BAR_H), (W, H)], fill=self._BAR)
+
+        # Bottom-left text block (above bottom letterbox bar)
+        name_font = load_font(64, bold=True)
+        title_font = load_font(32, bold=True)
+        detail_font = load_font(28)
+        small_font = load_font(22)
+
+        text_x = 120
+
+        # Count how many lines we need so we can position upward from the bar
+        lines = 0
+        if p["title"]:
+            lines += 1
+        lines += 1  # name (always)
+        if p["position"] or p["grad_year"]:
+            lines += 1
+        # Detail lines
+        detail_line1_parts = []
+        if p["club_team"]:
+            detail_line1_parts.append(p["club_team"])
+        if p["high_school"]:
+            detail_line1_parts.append(p["high_school"])
+        if detail_line1_parts:
+            lines += 1
+        detail_line2_parts = []
+        if p["height_weight"]:
+            detail_line2_parts.append(p["height_weight"])
+        if p["gpa"]:
+            detail_line2_parts.append(f"GPA {p['gpa']}")
+        if detail_line2_parts:
+            lines += 1
+        detail_line3_parts = []
+        if p["email"]:
+            detail_line3_parts.append(p["email"].lower())
+        if p["phone"]:
+            detail_line3_parts.append(p["phone"])
+        if detail_line3_parts:
+            lines += 1
+
+        # Start drawing from bottom, working upward
+        cursor_y = H - self._BAR_H - 40 - lines * 50
+
+        # Title
+        if p["title"]:
+            draw.text((text_x, cursor_y), p["title"], fill=self._TEXT_MUTED, font=title_font)
+            cursor_y += 45
+
+        # Name
+        draw.text((text_x, cursor_y), p["name"], fill=self._TEXT_WARM, font=name_font)
+        cursor_y += 80
+
+        # Position + grad year
+        sub_parts = []
+        if p["position"]:
+            sub_parts.append(p["position"].upper())
+        if p["grad_year"]:
+            sub_parts.append(f"Class of {p['grad_year']}")
+        if sub_parts:
+            draw.text((text_x, cursor_y), "  |  ".join(sub_parts),
+                       fill=self._TEXT_MUTED, font=detail_font)
+            cursor_y += 40
+
+        # Club / High School
+        if detail_line1_parts:
+            draw.text((text_x, cursor_y), "  ·  ".join(detail_line1_parts),
+                       fill=self._TEXT_MUTED, font=small_font)
+            cursor_y += 32
+
+        # Height/Weight / GPA
+        if detail_line2_parts:
+            draw.text((text_x, cursor_y), "  ·  ".join(detail_line2_parts),
+                       fill=self._TEXT_MUTED, font=small_font)
+            cursor_y += 32
+
+        # Email / Phone
+        if detail_line3_parts:
+            draw.text((text_x, cursor_y), "  ·  ".join(detail_line3_parts),
+                       fill=self._TEXT_MUTED, font=small_font)
+
+        return img
+
+    # ── video drawtext ─────────────────────────────────────────────
+
+    def get_video_drawtext_filters(self, player: dict, font_bold: str, font_regular: str) -> str:
+        p = extract_player_fields(player)
+        safe_name = escape_drawtext(p["name"])
+        sfb = escape_drawtext(font_bold) if font_bold else ""
+        sfr = escape_drawtext(font_regular) if font_regular else ""
+
+        filters: list[str] = []
+
+        # Title
+        if p["title"]:
+            safe_title = escape_drawtext(p["title"])
+            parts = [
+                f"drawtext=text='{safe_title}'",
+                f"fontsize=32",
+                f"fontcolor=#a09b91",
+                f"x=120",
+                f"y=h-340",
+                f"box=1",
+                f"boxcolor=black@0.4",
+                f"boxborderw=6",
+            ]
+            if sfb:
+                parts.insert(1, f"fontfile={sfb}")
+            filters.append(":".join(parts))
+
+        # Bottom-left name
+        parts = [
+            f"drawtext=text='{safe_name}'",
+            f"fontsize=64",
+            f"fontcolor=#f0e6d7",
+            f"x=120",
+            f"y=h-290",
+            f"box=1",
+            f"boxcolor=black@0.5",
+            f"boxborderw=10",
+        ]
+        if sfb:
+            parts.insert(1, f"fontfile={sfb}")
+        filters.append(":".join(parts))
+
+        # Position + grad year
+        sub_parts = []
+        if p["position"]:
+            sub_parts.append(p["position"].upper())
+        if p["grad_year"]:
+            sub_parts.append(f"Class of {p['grad_year']}")
+        if sub_parts:
+            safe_sub = escape_drawtext("  |  ".join(sub_parts))
+            parts = [
+                f"drawtext=text='{safe_sub}'",
+                f"fontsize=36",
+                f"fontcolor=#a09b91",
+                f"x=120",
+                f"y=h-210",
+                f"box=1",
+                f"boxcolor=black@0.4",
+                f"boxborderw=8",
+            ]
+            if sfr:
+                parts.insert(1, f"fontfile={sfr}")
+            filters.append(":".join(parts))
+
+        # Detail line: club · school · height/weight · gpa · contact
+        detail_parts = []
+        if p["club_team"]:
+            detail_parts.append(p["club_team"])
+        if p["high_school"]:
+            detail_parts.append(p["high_school"])
+        if p["height_weight"]:
+            detail_parts.append(p["height_weight"])
+        if p["gpa"]:
+            detail_parts.append(f"GPA {p['gpa']}")
+        if p["email"]:
+            detail_parts.append(p["email"].lower())
+        if p["phone"]:
+            detail_parts.append(p["phone"])
+        if detail_parts:
+            safe_detail = escape_drawtext("  ·  ".join(detail_parts))
+            parts = [
+                f"drawtext=text='{safe_detail}'",
+                f"fontsize=22",
+                f"fontcolor=#a09b91",
+                f"x=120",
+                f"y=h-155",
+                f"box=1",
+                f"boxcolor=black@0.4",
+                f"boxborderw=6",
+            ]
+            if sfr:
+                parts.insert(1, f"fontfile={sfr}")
+            filters.append(":".join(parts))
+
+        return ",".join(filters)

--- a/slate_templates/cinematic.py
+++ b/slate_templates/cinematic.py
@@ -167,7 +167,7 @@ class CinematicTemplate(SlateTemplate):
 
         filters: list[str] = []
 
-        # Title
+        # Title – matches image ~y=640 (h-440)
         if p["title"]:
             safe_title = escape_drawtext(p["title"])
             parts = [
@@ -175,7 +175,7 @@ class CinematicTemplate(SlateTemplate):
                 f"fontsize=32",
                 f"fontcolor=#a09b91",
                 f"x=120",
-                f"y=h-340",
+                f"y=h-440",
                 f"box=1",
                 f"boxcolor=black@0.4",
                 f"boxborderw=6",
@@ -184,13 +184,13 @@ class CinematicTemplate(SlateTemplate):
                 parts.insert(1, f"fontfile={sfb}")
             filters.append(":".join(parts))
 
-        # Bottom-left name
+        # Bottom-left name – matches image ~y=685 (h-395)
         parts = [
             f"drawtext=text='{safe_name}'",
             f"fontsize=64",
             f"fontcolor=#f0e6d7",
             f"x=120",
-            f"y=h-290",
+            f"y=h-395",
             f"box=1",
             f"boxcolor=black@0.5",
             f"boxborderw=10",
@@ -199,7 +199,7 @@ class CinematicTemplate(SlateTemplate):
             parts.insert(1, f"fontfile={sfb}")
         filters.append(":".join(parts))
 
-        # Position + grad year
+        # Position + grad year – matches image ~y=765 (h-315)
         sub_parts = []
         if p["position"]:
             sub_parts.append(p["position"].upper())
@@ -209,10 +209,10 @@ class CinematicTemplate(SlateTemplate):
             safe_sub = escape_drawtext("  |  ".join(sub_parts))
             parts = [
                 f"drawtext=text='{safe_sub}'",
-                f"fontsize=36",
+                f"fontsize=28",
                 f"fontcolor=#a09b91",
                 f"x=120",
-                f"y=h-210",
+                f"y=h-315",
                 f"box=1",
                 f"boxcolor=black@0.4",
                 f"boxborderw=8",
@@ -221,28 +221,64 @@ class CinematicTemplate(SlateTemplate):
                 parts.insert(1, f"fontfile={sfr}")
             filters.append(":".join(parts))
 
-        # Detail line: club · school · height/weight · gpa · contact
-        detail_parts = []
+        # Detail line 1: club · school – matches image ~y=805 (h-275)
+        detail1_parts = []
         if p["club_team"]:
-            detail_parts.append(p["club_team"])
+            detail1_parts.append(p["club_team"])
         if p["high_school"]:
-            detail_parts.append(p["high_school"])
-        if p["height_weight"]:
-            detail_parts.append(p["height_weight"])
-        if p["gpa"]:
-            detail_parts.append(f"GPA {p['gpa']}")
-        if p["email"]:
-            detail_parts.append(p["email"].lower())
-        if p["phone"]:
-            detail_parts.append(p["phone"])
-        if detail_parts:
-            safe_detail = escape_drawtext("  ·  ".join(detail_parts))
+            detail1_parts.append(p["high_school"])
+        if detail1_parts:
+            safe_d1 = escape_drawtext("  ·  ".join(detail1_parts))
             parts = [
-                f"drawtext=text='{safe_detail}'",
+                f"drawtext=text='{safe_d1}'",
                 f"fontsize=22",
                 f"fontcolor=#a09b91",
                 f"x=120",
-                f"y=h-155",
+                f"y=h-275",
+                f"box=1",
+                f"boxcolor=black@0.4",
+                f"boxborderw=6",
+            ]
+            if sfr:
+                parts.insert(1, f"fontfile={sfr}")
+            filters.append(":".join(parts))
+
+        # Detail line 2: height/weight · gpa – matches image ~y=837 (h-243)
+        detail2_parts = []
+        if p["height_weight"]:
+            detail2_parts.append(p["height_weight"])
+        if p["gpa"]:
+            detail2_parts.append(f"GPA {p['gpa']}")
+        if detail2_parts:
+            safe_d2 = escape_drawtext("  ·  ".join(detail2_parts))
+            parts = [
+                f"drawtext=text='{safe_d2}'",
+                f"fontsize=22",
+                f"fontcolor=#a09b91",
+                f"x=120",
+                f"y=h-243",
+                f"box=1",
+                f"boxcolor=black@0.4",
+                f"boxborderw=6",
+            ]
+            if sfr:
+                parts.insert(1, f"fontfile={sfr}")
+            filters.append(":".join(parts))
+
+        # Detail line 3: email · phone – matches image ~y=869 (h-211)
+        detail3_parts = []
+        if p["email"]:
+            detail3_parts.append(p["email"].lower())
+        if p["phone"]:
+            detail3_parts.append(p["phone"])
+        if detail3_parts:
+            safe_d3 = escape_drawtext("  ·  ".join(detail3_parts))
+            parts = [
+                f"drawtext=text='{safe_d3}'",
+                f"fontsize=22",
+                f"fontcolor=#a09b91",
+                f"x=120",
+                f"y=h-211",
                 f"box=1",
                 f"boxcolor=black@0.4",
                 f"boxborderw=6",

--- a/slate_templates/classic.py
+++ b/slate_templates/classic.py
@@ -1,0 +1,241 @@
+# Copyright (c) 2025 John Hull
+# Licensed under the MIT License - see LICENSE file
+"""Classic slate template – the original soccerhype design.
+
+Black background, gray corner brackets, "PLAYER PROFILE" header,
+gold labels, white data.  Photo left 33% / stats right 66%.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from PIL import Image, ImageDraw
+
+from .base import SlateTemplate, load_font, escape_drawtext, extract_player_fields
+
+
+class ClassicTemplate(SlateTemplate):
+    name = "classic"
+    display_name = "Classic"
+    description = "Black bg, gold labels, corner brackets – the original design"
+
+    # ── image-based slate ──────────────────────────────────────────
+
+    def render_image_slate(self, player: dict, intro_image: pathlib.Path | None) -> Image.Image:
+        W, H = 1920, 1080
+        img = Image.new("RGB", (W, H), (0, 0, 0))
+        draw = ImageDraw.Draw(img)
+
+        p = extract_player_fields(player)
+
+        # Corner brackets
+        bracket_color = (128, 128, 128)
+        bracket_size = 60
+        bracket_thickness = 4
+        margin = 80
+
+        # Top-left
+        draw.line([(margin, margin), (margin + bracket_size, margin)], fill=bracket_color, width=bracket_thickness)
+        draw.line([(margin, margin), (margin, margin + bracket_size)], fill=bracket_color, width=bracket_thickness)
+        # Top-right
+        draw.line([(W - margin - bracket_size, margin), (W - margin, margin)], fill=bracket_color, width=bracket_thickness)
+        draw.line([(W - margin, margin), (W - margin, margin + bracket_size)], fill=bracket_color, width=bracket_thickness)
+        # Bottom-left
+        draw.line([(margin, H - margin - bracket_size), (margin, H - margin)], fill=bracket_color, width=bracket_thickness)
+        draw.line([(margin, H - margin), (margin + bracket_size, H - margin)], fill=bracket_color, width=bracket_thickness)
+        # Bottom-right
+        draw.line([(W - margin, H - margin - bracket_size), (W - margin, H - margin)], fill=bracket_color, width=bracket_thickness)
+        draw.line([(W - margin - bracket_size, H - margin), (W - margin, H - margin)], fill=bracket_color, width=bracket_thickness)
+
+        # "PLAYER PROFILE" header
+        header_font = load_font(48)
+        header_text = "PLAYER PROFILE"
+        header_bbox = draw.textbbox((0, 0), header_text, font=header_font)
+        header_w = header_bbox[2] - header_bbox[0]
+        header_x = int(W * 0.66 - header_w // 2)
+        header_y = 120
+        draw.text((header_x, header_y), header_text, fill=(255, 255, 255), font=header_font)
+
+        # Colors and fonts
+        label_color = (255, 215, 0)   # Gold
+        data_color = (255, 255, 255)  # White
+        label_font = load_font(24)
+        data_font = load_font(36)
+        name_font = load_font(52)
+        title_font = load_font(72, bold=True)
+
+        # Build stat rows
+        stats_elements = []
+        if p["position"]:
+            stats_elements.append(("POSITION", p["position"].upper()))
+        if p["height_weight"]:
+            stats_elements.append(("HEIGHT | WEIGHT", p["height_weight"]))
+        if p["grad_year"]:
+            stats_elements.append(("GRADUATION YEAR", f"CLASS OF {p['grad_year']}"))
+        if p["club_team"]:
+            stats_elements.append(("CLUB", p["club_team"].upper()))
+        if p["high_school"]:
+            stats_elements.append(("HIGH SCHOOL", p["high_school"].upper()))
+        if p["gpa"]:
+            stats_elements.append(("GPA", str(p["gpa"])))
+        if p["email"]:
+            stats_elements.append(("EMAIL", p["email"].lower()))
+        if p["phone"]:
+            stats_elements.append(("PHONE", p["phone"]))
+
+        # Load intro image if provided
+        if intro_image:
+            pic_area_w, pic_area_h = 450, 600
+            pic_area_x = int(W * 0.33 - pic_area_w // 2)
+            pic_area_y = 220
+
+            try:
+                player_pic = Image.open(intro_image).convert("RGBA")
+                pic_w, pic_h = player_pic.size
+                scale = min(pic_area_w / pic_w, pic_area_h / pic_h, 1.0)
+                new_w, new_h = int(pic_w * scale), int(pic_h * scale)
+                player_pic = player_pic.resize((new_w, new_h), Image.LANCZOS)
+
+                # Rounded rectangle mask
+                mask = Image.new("L", (new_w, new_h), 0)
+                mask_draw = ImageDraw.Draw(mask)
+                mask_draw.rounded_rectangle([(0, 0), (new_w, new_h)], radius=20, fill=255)
+
+                rounded_pic = Image.new("RGBA", (new_w, new_h), (0, 0, 0, 0))
+                rounded_pic.paste(player_pic, (0, 0))
+                rounded_pic.putalpha(mask)
+
+                pic_x = pic_area_x + (pic_area_w - new_w) // 2
+                pic_y = pic_area_y + (pic_area_h - new_h) // 2
+
+                img_rgba = img.convert("RGBA")
+                img_rgba.paste(rounded_pic, (pic_x, pic_y), rounded_pic)
+                img = img_rgba.convert("RGB")
+                draw = ImageDraw.Draw(img)
+            except Exception as e:
+                print(f"Warning: Could not load picture {intro_image}: {e}")
+                intro_image = None
+
+        if intro_image:
+            # Title above name (if set), below picture, centered at 33%
+            below_pic_y = pic_area_y + pic_area_h + 20
+            if p["title"]:
+                tb = draw.textbbox((0, 0), p["title"], font=title_font)
+                tw = tb[2] - tb[0]
+                draw.text((int(W * 0.33 - tw // 2), below_pic_y), p["title"],
+                          fill=label_color, font=title_font)
+                below_pic_y += 75
+
+            name_bbox = draw.textbbox((0, 0), p["name"], font=name_font)
+            name_w = name_bbox[2] - name_bbox[0]
+            name_x = int(W * 0.33 - name_w // 2)
+            name_y = below_pic_y
+            draw.text((name_x, name_y), p["name"], fill=data_color, font=name_font)
+
+            # Stats centered at 66%
+            text_center_x = int(W * 0.66)
+            line_spacing = 85
+            total_height = len(stats_elements) * line_spacing - (line_spacing - 50) if stats_elements else 0
+            current_y = (H - total_height) // 2
+
+            for label, text in stats_elements:
+                bbox = draw.textbbox((0, 0), label, font=label_font)
+                lw = bbox[2] - bbox[0]
+                draw.text((text_center_x - lw // 2, current_y), label, fill=label_color, font=label_font)
+                bbox = draw.textbbox((0, 0), text, font=data_font)
+                dw = bbox[2] - bbox[0]
+                draw.text((text_center_x - dw // 2, current_y + 35), text, fill=data_color, font=data_font)
+                current_y += line_spacing
+        else:
+            # No picture – everything centred
+            below_header_y = header_y + 70
+            if p["title"]:
+                tb = draw.textbbox((0, 0), p["title"], font=title_font)
+                tw = tb[2] - tb[0]
+                draw.text(((W - tw) // 2, below_header_y), p["title"],
+                          fill=label_color, font=title_font)
+                below_header_y += 80
+
+            name_bbox = draw.textbbox((0, 0), p["name"], font=name_font)
+            name_w = name_bbox[2] - name_bbox[0]
+            name_x = (W - name_w) // 2
+            name_y = below_header_y
+            draw.text((name_x, name_y), p["name"], fill=data_color, font=name_font)
+
+            text_center_x = W // 2
+            line_spacing = 95
+            current_y = name_y + 100
+
+            for label, text in stats_elements:
+                bbox = draw.textbbox((0, 0), label, font=label_font)
+                lw = bbox[2] - bbox[0]
+                draw.text((text_center_x - lw // 2, current_y), label, fill=label_color, font=label_font)
+                bbox = draw.textbbox((0, 0), text, font=data_font)
+                dw = bbox[2] - bbox[0]
+                draw.text((text_center_x - dw // 2, current_y + 35), text, fill=data_color, font=data_font)
+                current_y += line_spacing
+
+        return img
+
+    # ── video-background slate (drawtext filters) ──────────────────
+
+    def get_video_drawtext_filters(self, player: dict, font_bold: str, font_regular: str) -> str:
+        p = extract_player_fields(player)
+        safe_name = escape_drawtext(p["name"])
+        safe_font_bold = escape_drawtext(font_bold) if font_bold else ""
+        safe_font_regular = escape_drawtext(font_regular) if font_regular else ""
+
+        filters: list[str] = []
+
+        # Title (above name)
+        if p["title"]:
+            safe_title = escape_drawtext(p["title"])
+            parts = [
+                f"drawtext=text='{safe_title}'",
+                f"fontsize=72",
+                f"fontcolor=#ffd700",
+                f"x=(w-text_w)/2",
+                f"y=h*0.65",
+                f"box=1",
+                f"boxcolor=black@0.7",
+                f"boxborderw=10",
+            ]
+            if safe_font_bold:
+                parts.insert(1, f"fontfile={safe_font_bold}")
+            filters.append(":".join(parts))
+
+        # Main name
+        parts = [
+            f"drawtext=text='{safe_name}'",
+            f"fontsize=64",
+            f"fontcolor=white",
+            f"x=(w-text_w)/2",
+            f"y=h*0.75",
+            f"box=1",
+            f"boxcolor=black@0.7",
+            f"boxborderw=10",
+        ]
+        if safe_font_bold:
+            parts.insert(1, f"fontfile={safe_font_bold}")
+        filters.append(":".join(parts))
+
+        # Position + grad year
+        if p["position"] or p["grad_year"]:
+            pos_line = p["position"] + (f"  •  Class of {p['grad_year']}" if p["grad_year"] else "")
+            safe_pos = escape_drawtext(pos_line)
+            parts = [
+                f"drawtext=text='{safe_pos}'",
+                f"fontsize=40",
+                f"fontcolor=white",
+                f"x=(w-text_w)/2",
+                f"y=h*0.82",
+                f"box=1",
+                f"boxcolor=black@0.7",
+                f"boxborderw=8",
+            ]
+            if safe_font_regular:
+                parts.insert(1, f"fontfile={safe_font_regular}")
+            filters.append(":".join(parts))
+
+        return ",".join(filters)

--- a/slate_templates/classic.py
+++ b/slate_templates/classic.py
@@ -188,7 +188,7 @@ class ClassicTemplate(SlateTemplate):
 
         filters: list[str] = []
 
-        # Title (above name)
+        # Title (above name) – matches image no-photo y=190
         if p["title"]:
             safe_title = escape_drawtext(p["title"])
             parts = [
@@ -196,7 +196,7 @@ class ClassicTemplate(SlateTemplate):
                 f"fontsize=72",
                 f"fontcolor=#ffd700",
                 f"x=(w-text_w)/2",
-                f"y=h*0.65",
+                f"y=190",
                 f"box=1",
                 f"boxcolor=black@0.7",
                 f"boxborderw=10",
@@ -205,13 +205,13 @@ class ClassicTemplate(SlateTemplate):
                 parts.insert(1, f"fontfile={safe_font_bold}")
             filters.append(":".join(parts))
 
-        # Main name
+        # Main name – matches image no-photo y=270
         parts = [
             f"drawtext=text='{safe_name}'",
-            f"fontsize=64",
+            f"fontsize=52",
             f"fontcolor=white",
             f"x=(w-text_w)/2",
-            f"y=h*0.75",
+            f"y=270",
             f"box=1",
             f"boxcolor=black@0.7",
             f"boxborderw=10",
@@ -220,7 +220,7 @@ class ClassicTemplate(SlateTemplate):
             parts.insert(1, f"fontfile={safe_font_bold}")
         filters.append(":".join(parts))
 
-        # Position + grad year
+        # Position + grad year – matches image no-photo stats start y=370
         if p["position"] or p["grad_year"]:
             pos_line = p["position"] + (f"  •  Class of {p['grad_year']}" if p["grad_year"] else "")
             safe_pos = escape_drawtext(pos_line)
@@ -229,7 +229,7 @@ class ClassicTemplate(SlateTemplate):
                 f"fontsize=40",
                 f"fontcolor=white",
                 f"x=(w-text_w)/2",
-                f"y=h*0.82",
+                f"y=370",
                 f"box=1",
                 f"boxcolor=black@0.7",
                 f"boxborderw=8",

--- a/slate_templates/clean.py
+++ b/slate_templates/clean.py
@@ -1,0 +1,212 @@
+# Copyright (c) 2025 John Hull
+# Licensed under the MIT License - see LICENSE file
+"""Clean slate template.
+
+Off-white (#f5f5f5) bg, dark text (#2c3e50), thin horizontal divider
+at 35% height, name above divider, stats below in clean grid,
+photo with thin border.  Video overlay uses white text for contrast.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from PIL import Image, ImageDraw
+
+from .base import SlateTemplate, load_font, escape_drawtext, extract_player_fields
+
+
+class CleanTemplate(SlateTemplate):
+    name = "clean"
+    display_name = "Clean"
+    description = "Light bg, dark text, horizontal divider – professional look"
+
+    _BG = (245, 245, 245)         # off-white
+    _TEXT_DARK = (44, 62, 80)     # #2c3e50
+    _TEXT_MID = (100, 100, 110)
+    _DIVIDER = (180, 180, 185)
+    _ACCENT = (41, 128, 185)      # steel blue
+    _BORDER = (200, 200, 205)
+
+    # ── image slate ────────────────────────────────────────────────
+
+    def render_image_slate(self, player: dict, intro_image: pathlib.Path | None) -> Image.Image:
+        W, H = 1920, 1080
+        img = Image.new("RGB", (W, H), self._BG)
+        draw = ImageDraw.Draw(img)
+
+        p = extract_player_fields(player)
+
+        divider_y = int(H * 0.35)
+
+        name_font = load_font(60, bold=True)
+        label_font = load_font(20)
+        data_font = load_font(30)
+        pos_font = load_font(32, bold=True)
+
+        photo_loaded = False
+        photo_right_edge = 0
+
+        if intro_image:
+            try:
+                pic = Image.open(intro_image).convert("RGB")
+                # Fit in box: max 320×320, positioned left of centre above divider
+                max_dim = 280
+                pw, ph = pic.size
+                scale = min(max_dim / pw, max_dim / ph, 1.0)
+                nw, nh = int(pw * scale), int(ph * scale)
+                pic = pic.resize((nw, nh), Image.LANCZOS)
+
+                # Thin border
+                border = 3
+                bx = 140
+                by = (divider_y - nh - border * 2) // 2 + 20
+                draw.rectangle(
+                    [(bx, by), (bx + nw + border * 2, by + nh + border * 2)],
+                    outline=self._BORDER, width=border,
+                )
+                img.paste(pic, (bx + border, by + border))
+                photo_loaded = True
+                photo_right_edge = bx + nw + border * 2 + 60
+            except Exception as e:
+                print(f"Warning: Could not load picture {intro_image}: {e}")
+
+        # Text area (above divider)
+        if photo_loaded:
+            name_x = photo_right_edge
+        else:
+            name_x = 140
+
+        # Title above name
+        name_y = divider_y - 110
+        if p["title"]:
+            title_font = load_font(28)
+            draw.text((name_x, name_y - 40), p["title"],
+                       fill=self._TEXT_MID, font=title_font)
+
+        draw.text((name_x, name_y), p["name"], fill=self._TEXT_DARK, font=name_font)
+
+        # Position below name
+        if p["position"]:
+            draw.text((name_x, name_y + 70), p["position"].upper(), fill=self._ACCENT, font=pos_font)
+
+        # Horizontal divider
+        draw.line([(100, divider_y), (W - 100, divider_y)], fill=self._DIVIDER, width=2)
+
+        # Stats grid below divider
+        stats = []
+        if p["grad_year"]:
+            stats.append(("GRADUATION YEAR", f"Class of {p['grad_year']}"))
+        if p["club_team"]:
+            stats.append(("CLUB TEAM", p["club_team"]))
+        if p["high_school"]:
+            stats.append(("HIGH SCHOOL", p["high_school"]))
+        if p["height_weight"]:
+            stats.append(("HEIGHT / WEIGHT", p["height_weight"]))
+        if p["gpa"]:
+            stats.append(("GPA", str(p["gpa"])))
+        if p["email"]:
+            stats.append(("EMAIL", p["email"].lower()))
+        if p["phone"]:
+            stats.append(("PHONE", p["phone"]))
+
+        grid_x = 140
+        grid_y = divider_y + 50
+        col_w = (W - 280) // 3
+        row_h = 85
+
+        for i, (label, value) in enumerate(stats):
+            col = i % 3
+            row = i // 3
+            x = grid_x + col * col_w
+            y = grid_y + row * row_h
+            draw.text((x, y), label, fill=self._TEXT_MID, font=label_font)
+            draw.text((x, y + 28), value, fill=self._TEXT_DARK, font=data_font)
+
+        return img
+
+    # ── video drawtext ─────────────────────────────────────────────
+
+    def get_video_drawtext_filters(self, player: dict, font_bold: str, font_regular: str) -> str:
+        """White text for contrast over video backgrounds."""
+        p = extract_player_fields(player)
+        safe_name = escape_drawtext(p["name"])
+        sfb = escape_drawtext(font_bold) if font_bold else ""
+        sfr = escape_drawtext(font_regular) if font_regular else ""
+
+        filters: list[str] = []
+
+        # Title (above name)
+        if p["title"]:
+            safe_title = escape_drawtext(p["title"])
+            parts = [
+                f"drawtext=text='{safe_title}'",
+                f"fontsize=28",
+                f"fontcolor=#cccccc",
+                f"x=(w-text_w)/2",
+                f"y=h*0.20",
+                f"box=1",
+                f"boxcolor=black@0.55",
+                f"boxborderw=6",
+            ]
+            if sfr:
+                parts.insert(1, f"fontfile={sfr}")
+            filters.append(":".join(parts))
+
+        # Name – centred upper third
+        parts = [
+            f"drawtext=text='{safe_name}'",
+            f"fontsize=60",
+            f"fontcolor=white",
+            f"x=(w-text_w)/2",
+            f"y=h*0.28",
+            f"box=1",
+            f"boxcolor=black@0.55",
+            f"boxborderw=12",
+        ]
+        if sfb:
+            parts.insert(1, f"fontfile={sfb}")
+        filters.append(":".join(parts))
+
+        # Position
+        if p["position"]:
+            safe_pos = escape_drawtext(p["position"].upper())
+            parts = [
+                f"drawtext=text='{safe_pos}'",
+                f"fontsize=36",
+                f"fontcolor=#2980b9",
+                f"x=(w-text_w)/2",
+                f"y=h*0.38",
+                f"box=1",
+                f"boxcolor=black@0.55",
+                f"boxborderw=8",
+            ]
+            if sfb:
+                parts.insert(1, f"fontfile={sfb}")
+            filters.append(":".join(parts))
+
+        # Stats line: grad year · club
+        info_parts = []
+        if p["grad_year"]:
+            info_parts.append(f"Class of {p['grad_year']}")
+        if p["club_team"]:
+            info_parts.append(p["club_team"])
+        if p["high_school"]:
+            info_parts.append(p["high_school"])
+        if info_parts:
+            safe_info = escape_drawtext("  ·  ".join(info_parts))
+            parts = [
+                f"drawtext=text='{safe_info}'",
+                f"fontsize=28",
+                f"fontcolor=#eeeeee",
+                f"x=(w-text_w)/2",
+                f"y=h*0.80",
+                f"box=1",
+                f"boxcolor=black@0.55",
+                f"boxborderw=8",
+            ]
+            if sfr:
+                parts.insert(1, f"fontfile={sfr}")
+            filters.append(":".join(parts))
+
+        return ",".join(filters)

--- a/slate_templates/clean.py
+++ b/slate_templates/clean.py
@@ -136,15 +136,15 @@ class CleanTemplate(SlateTemplate):
 
         filters: list[str] = []
 
-        # Title (above name)
+        # Title (above name) – matches image (name_x, divider_y-150) = (140, 228)
         if p["title"]:
             safe_title = escape_drawtext(p["title"])
             parts = [
                 f"drawtext=text='{safe_title}'",
                 f"fontsize=28",
                 f"fontcolor=#cccccc",
-                f"x=(w-text_w)/2",
-                f"y=h*0.20",
+                f"x=140",
+                f"y=228",
                 f"box=1",
                 f"boxcolor=black@0.55",
                 f"boxborderw=6",
@@ -153,13 +153,13 @@ class CleanTemplate(SlateTemplate):
                 parts.insert(1, f"fontfile={sfr}")
             filters.append(":".join(parts))
 
-        # Name – centred upper third
+        # Name – matches image (140, divider_y-110) = (140, 268)
         parts = [
             f"drawtext=text='{safe_name}'",
             f"fontsize=60",
             f"fontcolor=white",
-            f"x=(w-text_w)/2",
-            f"y=h*0.28",
+            f"x=140",
+            f"y=268",
             f"box=1",
             f"boxcolor=black@0.55",
             f"boxborderw=12",
@@ -168,15 +168,15 @@ class CleanTemplate(SlateTemplate):
             parts.insert(1, f"fontfile={sfb}")
         filters.append(":".join(parts))
 
-        # Position
+        # Position – matches image (140, divider_y-110+70) = (140, 338)
         if p["position"]:
             safe_pos = escape_drawtext(p["position"].upper())
             parts = [
                 f"drawtext=text='{safe_pos}'",
-                f"fontsize=36",
+                f"fontsize=32",
                 f"fontcolor=#2980b9",
-                f"x=(w-text_w)/2",
-                f"y=h*0.38",
+                f"x=140",
+                f"y=338",
                 f"box=1",
                 f"boxcolor=black@0.55",
                 f"boxborderw=8",
@@ -185,22 +185,48 @@ class CleanTemplate(SlateTemplate):
                 parts.insert(1, f"fontfile={sfb}")
             filters.append(":".join(parts))
 
-        # Stats line: grad year · club
-        info_parts = []
+        # Stats line 1 – matches image grid_y = divider_y+50 = 428
+        line1_parts = []
         if p["grad_year"]:
-            info_parts.append(f"Class of {p['grad_year']}")
+            line1_parts.append(f"Class of {p['grad_year']}")
         if p["club_team"]:
-            info_parts.append(p["club_team"])
+            line1_parts.append(p["club_team"])
         if p["high_school"]:
-            info_parts.append(p["high_school"])
-        if info_parts:
-            safe_info = escape_drawtext("  ·  ".join(info_parts))
+            line1_parts.append(p["high_school"])
+        if line1_parts:
+            safe_line1 = escape_drawtext("  ·  ".join(line1_parts))
             parts = [
-                f"drawtext=text='{safe_info}'",
+                f"drawtext=text='{safe_line1}'",
                 f"fontsize=28",
                 f"fontcolor=#eeeeee",
-                f"x=(w-text_w)/2",
-                f"y=h*0.80",
+                f"x=140",
+                f"y=428",
+                f"box=1",
+                f"boxcolor=black@0.55",
+                f"boxborderw=8",
+            ]
+            if sfr:
+                parts.insert(1, f"fontfile={sfr}")
+            filters.append(":".join(parts))
+
+        # Stats line 2 – matches image grid row 2 = 428+85 = 513
+        line2_parts = []
+        if p["height_weight"]:
+            line2_parts.append(p["height_weight"])
+        if p["gpa"]:
+            line2_parts.append(f"GPA {p['gpa']}")
+        if p["email"]:
+            line2_parts.append(p["email"].lower())
+        if p["phone"]:
+            line2_parts.append(p["phone"])
+        if line2_parts:
+            safe_line2 = escape_drawtext("  ·  ".join(line2_parts))
+            parts = [
+                f"drawtext=text='{safe_line2}'",
+                f"fontsize=28",
+                f"fontcolor=#cccccc",
+                f"x=140",
+                f"y=513",
                 f"box=1",
                 f"boxcolor=black@0.55",
                 f"boxborderw=8",

--- a/slate_templates/modern.py
+++ b/slate_templates/modern.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2025 John Hull
+# Licensed under the MIT License - see LICENSE file
+"""Modern slate template.
+
+Dark gradient (#1a1a2e → #16213e), 8px gold accent stripe on left,
+circular photo crop, clean two-column stats, accent-colored pill badge
+for position.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+from PIL import Image, ImageDraw
+
+from .base import SlateTemplate, load_font, escape_drawtext, extract_player_fields
+
+
+class ModernTemplate(SlateTemplate):
+    name = "modern"
+    display_name = "Modern"
+    description = "Dark gradient, gold accent stripe, circular photo crop"
+
+    _BG_TOP = (26, 26, 46)       # #1a1a2e
+    _BG_BOTTOM = (22, 33, 62)    # #16213e
+    _ACCENT = (218, 165, 32)     # gold
+    _TEXT_PRIMARY = (255, 255, 255)
+    _TEXT_SECONDARY = (180, 180, 200)
+
+    # ── helpers ────────────────────────────────────────────────────
+
+    @staticmethod
+    def _gradient(w: int, h: int, top: tuple, bottom: tuple) -> Image.Image:
+        img = Image.new("RGB", (w, h))
+        draw = ImageDraw.Draw(img)
+        for y in range(h):
+            t = y / max(h - 1, 1)
+            r = int(top[0] + (bottom[0] - top[0]) * t)
+            g = int(top[1] + (bottom[1] - top[1]) * t)
+            b = int(top[2] + (bottom[2] - top[2]) * t)
+            draw.line([(0, y), (w, y)], fill=(r, g, b))
+        return img
+
+    @staticmethod
+    def _circular_crop(photo: Image.Image, diameter: int) -> Image.Image:
+        # Crop to square first (center-x, top-biased-y) to avoid stretching
+        w, h = photo.size
+        side = min(w, h)
+        left = (w - side) // 2
+        top = min(h - side, h // 4)  # bias toward top to keep head
+        photo = photo.crop((left, top, left + side, top + side))
+        photo = photo.resize((diameter, diameter), Image.LANCZOS)
+        mask = Image.new("L", (diameter, diameter), 0)
+        ImageDraw.Draw(mask).ellipse((0, 0, diameter, diameter), fill=255)
+        out = Image.new("RGBA", (diameter, diameter), (0, 0, 0, 0))
+        out.paste(photo.convert("RGBA"), (0, 0))
+        out.putalpha(mask)
+        return out
+
+    # ── image slate ────────────────────────────────────────────────
+
+    def render_image_slate(self, player: dict, intro_image: pathlib.Path | None) -> Image.Image:
+        W, H = 1920, 1080
+        img = self._gradient(W, H, self._BG_TOP, self._BG_BOTTOM)
+        draw = ImageDraw.Draw(img)
+
+        p = extract_player_fields(player)
+
+        # Gold accent stripe (left edge)
+        draw.rectangle([(0, 0), (8, H)], fill=self._ACCENT)
+
+        name_font = load_font(56, bold=True)
+        label_font = load_font(22)
+        data_font = load_font(32)
+        pos_font = load_font(26, bold=True)
+
+        photo_diameter = 300
+        photo_loaded = False
+
+        if intro_image:
+            try:
+                raw = Image.open(intro_image).convert("RGBA")
+                circle = self._circular_crop(raw, photo_diameter)
+
+                # Gold ring around photo
+                ring = Image.new("RGBA", (photo_diameter + 8, photo_diameter + 8), (0, 0, 0, 0))
+                ring_draw = ImageDraw.Draw(ring)
+                ring_draw.ellipse((0, 0, photo_diameter + 7, photo_diameter + 7), fill=self._ACCENT)
+                ring_draw.ellipse((4, 4, photo_diameter + 3, photo_diameter + 3), fill=(0, 0, 0, 0))
+                ring.paste(circle, (4, 4), circle)
+
+                px = 120
+                py = (H - photo_diameter - 8) // 2
+
+                img_rgba = img.convert("RGBA")
+                img_rgba.paste(ring, (px, py), ring)
+                img = img_rgba.convert("RGB")
+                draw = ImageDraw.Draw(img)
+                photo_loaded = True
+            except Exception as e:
+                print(f"Warning: Could not load picture {intro_image}: {e}")
+
+        # Text layout
+        if photo_loaded:
+            text_x = 120 + photo_diameter + 80
+            text_w = W - text_x - 120
+        else:
+            text_x = 120
+            text_w = W - 240
+
+        # Title (if set)
+        name_y = 180
+        if p["title"]:
+            title_font = load_font(36, bold=True)
+            draw.text((text_x, 140), p["title"], fill=self._ACCENT, font=title_font)
+            name_y = 190
+
+        # Name
+        draw.text((text_x, name_y), p["name"], fill=self._TEXT_PRIMARY, font=name_font)
+
+        # Position pill badge
+        if p["position"]:
+            badge_text = p["position"].upper()
+            badge_font = pos_font
+            bb = draw.textbbox((0, 0), badge_text, font=badge_font)
+            bw, bh = bb[2] - bb[0], bb[3] - bb[1]
+            badge_x = text_x
+            badge_y = 260
+            draw.rounded_rectangle(
+                [(badge_x, badge_y), (badge_x + bw + 30, badge_y + bh + 14)],
+                radius=12, fill=self._ACCENT,
+            )
+            draw.text((badge_x + 15, badge_y + 7), badge_text, fill=(0, 0, 0), font=badge_font)
+
+        # Stats in two-column grid
+        stats = []
+        if p["grad_year"]:
+            stats.append(("GRAD YEAR", p["grad_year"]))
+        if p["club_team"]:
+            stats.append(("CLUB", p["club_team"]))
+        if p["high_school"]:
+            stats.append(("HIGH SCHOOL", p["high_school"]))
+        if p["height_weight"]:
+            stats.append(("HEIGHT / WEIGHT", p["height_weight"]))
+        if p["gpa"]:
+            stats.append(("GPA", str(p["gpa"])))
+        if p["email"]:
+            stats.append(("EMAIL", p["email"].lower()))
+        if p["phone"]:
+            stats.append(("PHONE", p["phone"]))
+
+        col_w = text_w // 2
+        start_y = 340
+        row_h = 90
+
+        for i, (label, value) in enumerate(stats):
+            col = i % 2
+            row = i // 2
+            x = text_x + col * col_w
+            y = start_y + row * row_h
+            draw.text((x, y), label, fill=self._TEXT_SECONDARY, font=label_font)
+            draw.text((x, y + 30), value, fill=self._TEXT_PRIMARY, font=data_font)
+
+        return img
+
+    # ── video drawtext ─────────────────────────────────────────────
+
+    def get_video_drawtext_filters(self, player: dict, font_bold: str, font_regular: str) -> str:
+        p = extract_player_fields(player)
+        safe_name = escape_drawtext(p["name"])
+        sfb = escape_drawtext(font_bold) if font_bold else ""
+        sfr = escape_drawtext(font_regular) if font_regular else ""
+
+        filters: list[str] = []
+
+        # Title (above name)
+        if p["title"]:
+            safe_title = escape_drawtext(p["title"])
+            parts = [
+                f"drawtext=text='{safe_title}'",
+                f"fontsize=36",
+                f"fontcolor=#daa520",
+                f"x=80",
+                f"y=h*0.64",
+                f"box=1",
+                f"boxcolor=black@0.6",
+                f"boxborderw=8",
+            ]
+            if sfb:
+                parts.insert(1, f"fontfile={sfb}")
+            filters.append(":".join(parts))
+
+        # Name – bottom left with accent-colored underline effect via box
+        parts = [
+            f"drawtext=text='{safe_name}'",
+            f"fontsize=64",
+            f"fontcolor=white",
+            f"x=80",
+            f"y=h*0.72",
+            f"box=1",
+            f"boxcolor=black@0.6",
+            f"boxborderw=12",
+        ]
+        if sfb:
+            parts.insert(1, f"fontfile={sfb}")
+        filters.append(":".join(parts))
+
+        # Position badge
+        if p["position"]:
+            safe_pos = escape_drawtext(p["position"].upper())
+            parts = [
+                f"drawtext=text='{safe_pos}'",
+                f"fontsize=32",
+                f"fontcolor=#1a1a2e",
+                f"x=80",
+                f"y=h*0.82",
+                f"box=1",
+                f"boxcolor=#daa520",
+                f"boxborderw=10",
+            ]
+            if sfb:
+                parts.insert(1, f"fontfile={sfb}")
+            filters.append(":".join(parts))
+
+        # Grad year
+        if p["grad_year"]:
+            safe_grad = escape_drawtext(f"Class of {p['grad_year']}")
+            parts = [
+                f"drawtext=text='{safe_grad}'",
+                f"fontsize=36",
+                f"fontcolor=white",
+                f"x=80+text_w+40" if p["position"] else f"x=80",
+                f"y=h*0.82",
+                f"box=1",
+                f"boxcolor=black@0.5",
+                f"boxborderw=8",
+            ]
+            if sfr:
+                parts.insert(1, f"fontfile={sfr}")
+            filters.append(":".join(parts))
+
+        return ",".join(filters)

--- a/slate_templates/modern.py
+++ b/slate_templates/modern.py
@@ -173,15 +173,15 @@ class ModernTemplate(SlateTemplate):
 
         filters: list[str] = []
 
-        # Title (above name)
+        # Title (above name) – matches image text_x=120, y=140
         if p["title"]:
             safe_title = escape_drawtext(p["title"])
             parts = [
                 f"drawtext=text='{safe_title}'",
                 f"fontsize=36",
                 f"fontcolor=#daa520",
-                f"x=80",
-                f"y=h*0.64",
+                f"x=120",
+                f"y=140",
                 f"box=1",
                 f"boxcolor=black@0.6",
                 f"boxborderw=8",
@@ -190,13 +190,13 @@ class ModernTemplate(SlateTemplate):
                 parts.insert(1, f"fontfile={sfb}")
             filters.append(":".join(parts))
 
-        # Name – bottom left with accent-colored underline effect via box
+        # Name – matches image y=190
         parts = [
             f"drawtext=text='{safe_name}'",
-            f"fontsize=64",
+            f"fontsize=56",
             f"fontcolor=white",
-            f"x=80",
-            f"y=h*0.72",
+            f"x=120",
+            f"y=190",
             f"box=1",
             f"boxcolor=black@0.6",
             f"boxborderw=12",
@@ -205,15 +205,15 @@ class ModernTemplate(SlateTemplate):
             parts.insert(1, f"fontfile={sfb}")
         filters.append(":".join(parts))
 
-        # Position badge
+        # Position badge – matches image y=260
         if p["position"]:
             safe_pos = escape_drawtext(p["position"].upper())
             parts = [
                 f"drawtext=text='{safe_pos}'",
-                f"fontsize=32",
+                f"fontsize=26",
                 f"fontcolor=#1a1a2e",
-                f"x=80",
-                f"y=h*0.82",
+                f"x=120",
+                f"y=270",
                 f"box=1",
                 f"boxcolor=#daa520",
                 f"boxborderw=10",
@@ -222,15 +222,48 @@ class ModernTemplate(SlateTemplate):
                 parts.insert(1, f"fontfile={sfb}")
             filters.append(":".join(parts))
 
-        # Grad year
+        # Stats line 1 – matches image grid start y=340
+        line1_parts = []
         if p["grad_year"]:
-            safe_grad = escape_drawtext(f"Class of {p['grad_year']}")
+            line1_parts.append(f"Class of {p['grad_year']}")
+        if p["club_team"]:
+            line1_parts.append(p["club_team"])
+        if p["high_school"]:
+            line1_parts.append(p["high_school"])
+        if line1_parts:
+            safe_line1 = escape_drawtext("  ·  ".join(line1_parts))
             parts = [
-                f"drawtext=text='{safe_grad}'",
-                f"fontsize=36",
+                f"drawtext=text='{safe_line1}'",
+                f"fontsize=32",
                 f"fontcolor=white",
-                f"x=80+text_w+40" if p["position"] else f"x=80",
-                f"y=h*0.82",
+                f"x=120",
+                f"y=340",
+                f"box=1",
+                f"boxcolor=black@0.5",
+                f"boxborderw=8",
+            ]
+            if sfr:
+                parts.insert(1, f"fontfile={sfr}")
+            filters.append(":".join(parts))
+
+        # Stats line 2 – matches image grid row 2 y=430
+        line2_parts = []
+        if p["height_weight"]:
+            line2_parts.append(p["height_weight"])
+        if p["gpa"]:
+            line2_parts.append(f"GPA {p['gpa']}")
+        if p["email"]:
+            line2_parts.append(p["email"].lower())
+        if p["phone"]:
+            line2_parts.append(p["phone"])
+        if line2_parts:
+            safe_line2 = escape_drawtext("  ·  ".join(line2_parts))
+            parts = [
+                f"drawtext=text='{safe_line2}'",
+                f"fontsize=32",
+                f"fontcolor=#b4b4c8",
+                f"x=120",
+                f"y=430",
                 f"box=1",
                 f"boxcolor=black@0.5",
                 f"boxborderw=8",

--- a/soccerhype_gui.py
+++ b/soccerhype_gui.py
@@ -728,6 +728,7 @@ class SoccerHypeGUI:
         self.context_menu = tk.Menu(self.root, tearoff=0)
         self.context_menu.add_command(label="Open Folder", command=self.open_folder)
         self.context_menu.add_command(label="Set Profile", command=self.set_profile)
+        self.context_menu.add_command(label="Choose Slate...", command=self.choose_slate_template)
         self.context_menu.add_separator()
         self.context_menu.add_command(label="Order Clips", command=self.reorder_clips)
         self.context_menu.add_command(label="Mark Plays", command=self.mark_plays)
@@ -1266,6 +1267,83 @@ class SoccerHypeGUI:
             # Profile was saved by the dialog, refresh the list
             self.refresh_athletes()
 
+    def choose_slate_template(self):
+        """Open the slate template chooser for the selected project."""
+        from slate_template_chooser import SlateTemplateChooser
+
+        athlete_dir, project_dir = self.get_selected_project()
+        if not athlete_dir or not project_dir:
+            return
+
+        # Load player data for preview rendering
+        v2 = is_v2_structure(athlete_dir)
+        if v2:
+            player = get_athlete_profile(athlete_dir)
+        else:
+            project_path = project_dir / "project.json"
+            if project_path.exists():
+                try:
+                    data = json.loads(project_path.read_text())
+                    player = data.get("player", {})
+                except (IOError, json.JSONDecodeError):
+                    player = {}
+            else:
+                player = {}
+
+        if not player.get("name"):
+            messagebox.showwarning("No Profile",
+                                   "Set a player profile first so previews can be rendered.")
+            return
+
+        # Resolve intro image for previews
+        intro_image = None
+        project_path = project_dir / "project.json"
+        if project_path.exists():
+            try:
+                proj_data = json.loads(project_path.read_text())
+                media_rel = proj_data.get("intro_media")
+                if media_rel:
+                    if v2:
+                        candidate = athlete_dir / media_rel
+                    else:
+                        candidate = project_dir / media_rel
+                    # Only use images, not videos, for the static preview
+                    if candidate.exists() and candidate.suffix.lower() in {
+                        ".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp"
+                    }:
+                        intro_image = candidate
+            except (IOError, json.JSONDecodeError):
+                pass
+
+        # Current template from project.json
+        current_template = None
+        if project_path.exists():
+            try:
+                proj_data = json.loads(project_path.read_text())
+                current_template = proj_data.get("slate_template")
+            except (IOError, json.JSONDecodeError):
+                pass
+
+        result = SlateTemplateChooser.choose(
+            self.root, player, intro_image, current=current_template
+        )
+
+        if result is not None:
+            # Save to project.json
+            if project_path.exists():
+                try:
+                    proj_data = json.loads(project_path.read_text())
+                    proj_data["slate_template"] = result
+                    with open(project_path, "w") as f:
+                        json.dump(proj_data, f, indent=2)
+                    messagebox.showinfo("Slate Template",
+                                        f"Template set to: {result.title()}")
+                except (IOError, json.JSONDecodeError) as e:
+                    messagebox.showerror("Error", f"Failed to save template choice:\n{e}")
+            else:
+                messagebox.showwarning("No Project",
+                                       "No project.json found. Set up the project first.")
+
     def mark_plays(self):
         """Launch mark_play.py for selected project (directly from row)"""
         athlete_dir, project_dir = self.get_selected_project()
@@ -1715,6 +1793,26 @@ class PlayerInfoDialog:
         tk.Button(media_btn_frame, text="Clear Selection", command=self.clear_media_selection,
                  font=("Segoe UI", 9)).pack(side='left')
 
+        # Slate Template Section
+        slate_frame = tk.Frame(scrollable_frame, relief="solid", bd=1, bg="#f8f9fa")
+        slate_frame.pack(fill='x', pady=15)
+
+        tk.Label(slate_frame, text="Slate Template",
+                 font=("Segoe UI", 12, "bold"), bg="#f8f9fa").pack(anchor='w', padx=10, pady=(10, 5))
+
+        slate_inner = tk.Frame(slate_frame, bg="#f8f9fa")
+        slate_inner.pack(fill='x', padx=10, pady=(0, 10))
+
+        self.slate_template_var = tk.StringVar(value="classic")
+        self.slate_template_label = tk.Label(
+            slate_inner, text="Current: Classic (default)",
+            font=("Segoe UI", 9), bg="#f8f9fa")
+        self.slate_template_label.pack(anchor='w', pady=(0, 5))
+
+        tk.Button(slate_inner, text="Change Template...",
+                  command=self._open_slate_chooser,
+                  font=("Segoe UI", 9)).pack(anchor='w')
+
         # Checkboxes
         checkbox_frame = tk.Frame(scrollable_frame)
         checkbox_frame.pack(fill='x', pady=15)
@@ -1747,6 +1845,20 @@ class PlayerInfoDialog:
                 if athlete_json.exists():
                     data = json.loads(athlete_json.read_text())
                     self._populate_form_from_data(data)
+                # v2: Load slate_template from first project's project.json
+                projects_dir = self.athlete_dir / "projects"
+                if projects_dir.exists():
+                    for pdir in sorted(projects_dir.iterdir()):
+                        pjson = pdir / "project.json"
+                        if pjson.exists():
+                            pdata = json.loads(pjson.read_text())
+                            tpl = pdata.get("slate_template")
+                            if tpl:
+                                self.slate_template_var.set(tpl)
+                                from slate_templates import get_template
+                                self.slate_template_label.config(
+                                    text=f"Current: {get_template(tpl).display_name}")
+                            break
             else:
                 # v1: Load from project.json
                 project_json = self.athlete_dir / "project.json"
@@ -1761,6 +1873,13 @@ class PlayerInfoDialog:
                         if intro_path.exists():
                             self.selected_media_var.set(str(intro_path))
                             self.current_media_label.config(text=f"Selected: {intro_path.name}")
+                    # Load slate template
+                    tpl = data.get("slate_template")
+                    if tpl:
+                        self.slate_template_var.set(tpl)
+                        from slate_templates import get_template
+                        self.slate_template_label.config(
+                            text=f"Current: {get_template(tpl).display_name}")
         except (IOError, json.JSONDecodeError):
             pass  # No existing data to load
 
@@ -1806,6 +1925,44 @@ class PlayerInfoDialog:
                 self.current_media_label.config(text=f"Found {len(self.media_files)} media file(s) in intro folder")
             else:
                 self.current_media_label.config(text="No media files found in intro folder")
+
+    def _open_slate_chooser(self):
+        """Open the slate template chooser dialog."""
+        from slate_template_chooser import SlateTemplateChooser
+        from slate_templates import get_template
+
+        # Build player dict from current form values
+        player = {
+            "name": self.name_var.get().strip() or "Player Name",
+            "position": self.position_var.get().strip(),
+            "grad_year": self.grad_year_var.get().strip(),
+            "club_team": self.club_team_var.get().strip(),
+            "high_school": self.high_school_var.get().strip(),
+            "height_weight": self.height_weight_var.get().strip(),
+            "gpa": self.gpa_var.get().strip(),
+            "email": self.email_var.get().strip(),
+            "phone": self.phone_var.get().strip(),
+        }
+
+        # Resolve intro image for preview
+        intro_image = None
+        media_path_str = self.selected_media_var.get()
+        if media_path_str:
+            candidate = pathlib.Path(media_path_str)
+            if candidate.exists() and candidate.suffix.lower() in {
+                ".jpg", ".jpeg", ".png", ".bmp", ".gif", ".webp"
+            }:
+                intro_image = candidate
+
+        result = SlateTemplateChooser.choose(
+            self.dialog, player, intro_image,
+            current=self.slate_template_var.get()
+        )
+
+        if result is not None:
+            self.slate_template_var.set(result)
+            tpl = get_template(result)
+            self.slate_template_label.config(text=f"Current: {tpl.display_name}")
 
     def browse_media(self):
         """Browse and upload media files"""
@@ -2027,6 +2184,12 @@ class PlayerInfoDialog:
                                     # Only update intro_media if not already set
                                     if not project_data.get("intro_media") and intro_media:
                                         project_data["intro_media"] = intro_media
+                                    # Update slate template
+                                    tpl_val = self.slate_template_var.get()
+                                    if tpl_val and tpl_val != "classic":
+                                        project_data["slate_template"] = tpl_val
+                                    elif "slate_template" in project_data and tpl_val == "classic":
+                                        project_data["slate_template"] = None
                                     with open(project_json_path, 'w') as f:
                                         json.dump(project_data, f, indent=2)
                                 except (IOError, json.JSONDecodeError):
@@ -2047,10 +2210,12 @@ class PlayerInfoDialog:
                     except (IOError, json.JSONDecodeError):
                         pass
 
+                tpl_val = self.slate_template_var.get()
                 project_data = {
                     "player": player_data,
                     "include_intro": self.include_intro_var.get(),
                     "intro_media": intro_media,
+                    "slate_template": tpl_val if tpl_val != "classic" else None,
                     "clips": existing_clips
                 }
 

--- a/soccerhype_gui.py
+++ b/soccerhype_gui.py
@@ -79,6 +79,8 @@ def _extract_video_frame(video_path: pathlib.Path) -> pathlib.Path | None:
             return tmp
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
+    # Clean up temp file on failure
+    tmp.unlink(missing_ok=True)
     return None
 
 

--- a/soccerhype_gui.py
+++ b/soccerhype_gui.py
@@ -66,7 +66,9 @@ def _extract_video_frame(video_path: pathlib.Path) -> pathlib.Path | None:
     Returns path to a temporary PNG, or None on failure.
     """
     import tempfile
-    tmp = pathlib.Path(tempfile.mktemp(suffix=".png", prefix="slate_preview_"))
+    tmp_fd = tempfile.NamedTemporaryFile(suffix=".png", prefix="slate_preview_", delete=False)
+    tmp = pathlib.Path(tmp_fd.name)
+    tmp_fd.close()
     try:
         subprocess.run(
             ["ffmpeg", "-y", "-ss", "1", "-i", str(video_path),

--- a/utils/structure.py
+++ b/utils/structure.py
@@ -416,6 +416,7 @@ def create_project(athlete_dir: pathlib.Path, project_name: str) -> pathlib.Path
         "project_name": project_name,
         "include_intro": True,
         "intro_media": None,
+        "slate_template": None,
         "clips": []
     }
     _atomic_write_json(project_dir / "project.json", project_data)
@@ -518,6 +519,7 @@ def clone_project(
                 "project_name": target_project,
                 "include_intro": True,
                 "intro_media": None,
+                "slate_template": None,
                 "clips": []
             }
             _atomic_write_json(temp_dir / "project.json", project_data)


### PR DESCRIPTION
## Summary
- Adds 5 slate templates (classic, modern, bold, cinematic, clean) with a visual chooser dialog for selecting templates with live previews
- Aligns video drawtext positions to match image slate layouts so switching between photo and video intros produces consistent text placement
- Adds video frame extraction for slate chooser previews — selecting a video intro now shows video content in template previews instead of a blank background

## Test plan
- [ ] Open slate template chooser with an image intro selected — verify all 5 previews render correctly
- [ ] Open slate template chooser with a video intro selected — verify previews show video frame as background
- [ ] Render a highlight with image intro, note text positions on slate
- [ ] Render same template with video intro, verify text appears in the same screen region
- [ ] Test with full profile data and minimal profile data (name only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)